### PR TITLE
Fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ switch is used to control how croniter handles **day** and **day_of_week**
 entries. Default option is the cron behaviour, which connects those
 values using **OR**. If the switch is set to False, the values are connected
 using **AND**. This behaves like fcron and enables you to e.g. define a job that
-executes each 2nd friday of a month by setting the days of month and the
+executes each 2nd Friday of a month by setting the days of month and the
 weekday.
 ::
 
@@ -115,7 +115,7 @@ Example using python_dateutil::
 
 About second repeats
 =====================
-Croniter is able to do second repeatition crontabs form::
+Croniter is able to do second repetition crontabs form::
 
     >>> croniter('* * * * * 1', local_date).get_next(datetime)
     >>> base = datetime(2012, 4, 6, 13, 26, 10)

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -262,7 +262,7 @@ Changelog
 
 0.3.17 (2017-05-22)
 -------------------
-- DOW occurence sharp style support.
+- DOW occurrence sharp style support.
   [kiorky, Kengo Seki <sekikn@apache.org>]
 
 

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -18,7 +18,7 @@ import random
 try:
     from collections import OrderedDict
 except ImportError:
-    OrderedDict = dict  # py26 degraded mode, expanders order wont be immutable
+    OrderedDict = dict  # py26 degraded mode, expanders order will not be immutable
 
 
 step_search_re = re.compile(r'^([^-]+)-([^-/]+)(/(\d+))?$')
@@ -247,7 +247,7 @@ class croniter(object):
             result = self._calc(self.cur, expanded,
                                 nth_weekday_of_month, is_prev)
 
-        # DST Handling for cron job spanning accross days
+        # DST Handling for cron job spanning across days
         dtstarttime = self._timestamp_to_datetime(self.dst_start_time)
         dtstarttime_utcoffset = (
             dtstarttime.utcoffset() or datetime.timedelta(0))
@@ -287,7 +287,7 @@ class croniter(object):
         implicit call to __iter__, whenever non-default
         'ret_type' has to be specified.
         '''
-        # In a Python 3.7+ world:  contextlib.supress and contextlib.nullcontext could be used instead
+        # In a Python 3.7+ world:  contextlib.suppress and contextlib.nullcontext could be used instead
         try:
             while True:
                 self._is_prev = False

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -702,7 +702,7 @@ class CroniterTest(base.TestCase):
         itr = croniter('* * * * *')
         sleep(.01)
         itr2 = croniter('* * * * *')
-        # Greater dosnt exists in py26
+        # Greater does not exists in py26
         self.assertTrue(itr2.cur > itr.cur)
 
     def assertScheduleTimezone(self, callback, expected_schedule):

--- a/src/croniter/tests/test_croniter_hash.py
+++ b/src/croniter/tests/test_croniter_hash.py
@@ -113,7 +113,7 @@ class CroniterHashTest(CroniterHashBase):
         self._test_iter('H H * * *', 1577877000.0, (60 * 60 * 24), next_type=float)
 
     def test_invalid_definition(self):
-        """Test an invalid defition raises CroniterNotAlphaError"""
+        """Test an invalid definition raises CroniterNotAlphaError"""
         with self.assertRaises(CroniterNotAlphaError):
             croniter('X X * * *', self.epoch, hash_id=self.hash_id)
 


### PR DESCRIPTION
Just some typo fixes, no code changes. It seemed like some of these were trying to avoid using apostrophes so I expanded contractions to not need apostrophes.