### PR TITLE
Added DST example using only the builtin datetime module.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,11 @@ Example using python_dateutil::
     >>> local_date = datetime(2017, 3, 26, tzinfo=tz)
     >>> val = croniter('0 0 * * *', local_date).get_next(datetime)
 
+Example using python built in module::
+
+    >>> from datetime import datetime, timezone
+    >>> local_date = datetime(2017, 3, 26, tzinfo=timezone.utc)
+    >>> val = croniter('0 0 * * *', local_date).get_next(datetime)
 
 About second repeats
 =====================


### PR DESCRIPTION
Hi,

From python 3.2 onwards there's a tzinfo class present for UTC. This pull request adds an example to the README.rst on how to use this.

Thanks for the great library!

Kind regards,
Thiezn
