### PR TITLE
Fix #12: `set_current(force=True)` by default

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -175,7 +175,7 @@ class croniter(object):
             return self._timestamp_to_datetime(self.cur)
         return self.cur
 
-    def set_current(self, start_time, force=False):
+    def set_current(self, start_time, force=True):
         if (force or (self.cur is None)) and start_time is not None:
             if isinstance(start_time, datetime.datetime):
                 self.tzinfo = start_time.tzinfo

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from time import sleep
 import pytz
@@ -1451,6 +1451,13 @@ class CroniterTest(base.TestCase):
             self.assertEqual(nt.tzinfo.zone, 'America/New_York')
             self.assertEqual(int(croniter._datetime_to_timestamp(nt)), 1547481660)
 
+    def test_issue_12(self):
+        base = datetime(2010, 1, 23, 12, 18, tzinfo=timezone.utc)
+        itr = croniter('* * * * *')
+        itr.set_current(start_time=base)
+        n1 = itr.get_next()   # 19
+
+        self.assertEqual(n1, base.timestamp() + 60)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
@kiorky I've started a PR that includes a simple test case for this issue and a proposed solution

The test case fails on master, passes on v1.2.0. As far as I can tell, during https://github.com/kiorky/croniter/commit/1ea781aa1936214088fa6451c5d62537045869dd, the `set_current()` method signature slightly changed, including an optional `force` parameter with a default to `False`.

When calling `set_current(start_time)` before `get_next()`, [which Procrastinate does](https://github.com/procrastinate-org/procrastinate/blob/main/procrastinate/periodic.py#L151-L154), without specifying `force`, the `set_current()` call is basically a no-op, which causes the change of behaviour.

My suggested fix is to switch the default value for the `force` argument to `True`. This fixes the test, restores backward compatibility, and also makes more sense from a UX point of view IMHO: if you're calling `set_current()` with a non null `start_time`, you most likely *do* want it to be used :)