### PR TITLE
Fix croniter_range infinite loop

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -279,8 +279,12 @@ class croniter(object):
                 or (lag < 0 and
                     ((3600 * abs(lag_hours) + abs(lag)) >= hours_before_midnight * 3600))
             ):
-                dtresult = dtresult - datetime.timedelta(seconds=lag)
-                result = self._datetime_to_timestamp(dtresult)
+                dtresult_adjusted = dtresult - datetime.timedelta(seconds=lag)
+                result_adjusted = self._datetime_to_timestamp(dtresult_adjusted)
+                # Do the actual adjust only if the result time actually exists
+                if self._timestamp_to_datetime(result_adjusted).tzinfo == dtresult_adjusted.tzinfo:
+                    dtresult = dtresult_adjusted
+                    result = result_adjusted
                 self.dst_start_time = result
         self.cur = result
         if issubclass(ret_type, datetime.datetime):

--- a/src/croniter/tests/test_croniter_range.py
+++ b/src/croniter/tests/test_croniter_range.py
@@ -160,6 +160,20 @@ class CroniterRangeTest(base.TestCase):
         except CroniterBadTypeRangeError:
             self.fail('should not be triggered')
 
+    def test_dst_iter(self):
+        tz = pytz.timezone('Asia/Hebron')
+        now = datetime(2022, 3, 26, 0, 0, 0, tzinfo=tz)
+        it = croniter('0 0 * * *', now)
+        ret = [
+            it.get_next(datetime).isoformat(),
+            it.get_next(datetime).isoformat(),
+            it.get_next(datetime).isoformat(),
+        ]
+        self.assertEqual(ret, [
+            '2022-03-26T00:00:00+02:00',
+            '2022-03-27T01:00:00+03:00',
+            '2022-03-28T00:00:00+03:00'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The issue was caused due to the fact that the result time was adjusted unconditionally
though it might have resulted in datetime that does not really exist.

e.g.
If the clock was moved 1 hour forward at March 27 00:00, we do not have that time,
but rather March 27 01:00. If we adjust it we get March 26 23:00.

Closes: #20 