### PR TITLE
Do not expose `i` into global namespace

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -29,6 +29,7 @@ DOW_ALPHAS = {'sun': 0, 'mon': 1, 'tue': 2, 'wed': 3, 'thu': 4, 'fri': 5, 'sat':
 ALPHAS = {}
 for i in M_ALPHAS, DOW_ALPHAS:
     ALPHAS.update(i)
+del i
 step_search_re = re.compile(r'^([^-]+)-([^-/]+)(/(\d+))?$')
 only_int_re = re.compile(r'^\d+$')
 


### PR DESCRIPTION
Hi, I am working on stubs for this module in `python/typeshed`, looks like this symbol is exposed: https://github.com/python/typeshed/actions/runs/4647756507/jobs/8224937971#step:5:229

I don't think that this is intentional, so it is better to remove it.