### PR TITLE
Adding check for range begin end

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -907,6 +907,10 @@ class HashExpander:
 
         if m['hash_type'] == 'h' and hash_id is None:
             raise CroniterBadCronError('Hashed definitions must include hash_id')
+        
+        if m['range_begin'] and m['range_end']:
+            if int(m['range_begin']) >=  int(m['range_end']):
+                raise CroniterBadCronError('Range end must be greater than range begin')
 
         if m['range_begin'] and m['range_end'] and m['divisor']:
             # Example: H(30-59)/10 -> 34-59/10 (i.e. 34,44,54)

--- a/src/croniter/tests/test_croniter_hash.py
+++ b/src/croniter/tests/test_croniter_hash.py
@@ -98,6 +98,16 @@ class CroniterHashTest(CroniterHashBase):
         self._test_iter(
             'H(30-59)/10 H * * *', datetime(2020, 1, 1, 11, 31), timedelta(minutes=10)
         )
+    
+    def test_hash_invalid_range(self):
+        """Test validation logic for range_begin and range_end values"""
+        try:
+            self._test_iter(
+                'H(11-10) H * * *', datetime(2020, 1, 1, 11, 31), timedelta(minutes=10)
+            )
+        except (CroniterBadCronError) as ex:
+            self.assertEqual("{0}".format(ex),
+                'Range end must be greater than range begin')
 
     def test_hash_id_bytes(self):
         """Test hash_id as a bytes object"""


### PR DESCRIPTION
Following on from issue #37 "Division by zero possible with ranges", this change adds a check that `range_end` is `> range_begin` before trying to process the schedule. And adding a test case that provides an example of this issue to ensure the exception is raised.