### PR TITLE
Enhance .match() precision for 6 position expressions

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -817,7 +817,8 @@ class croniter(object):
             td = td + ms1
         cron.set_current(td, force=True)
         tdp, tdt = cron.get_current(), cron.get_prev()
-        return (max(tdp, tdt) - min(tdp, tdt)).total_seconds() < 60
+        precision_in_seconds = 1 if len(cron.expanded) == 6 else 60
+        return (max(tdp, tdt) - min(tdp, tdt)).total_seconds() < precision_in_seconds
 
 
 def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude_ends=False,

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1015,6 +1015,14 @@ class CroniterTest(base.TestCase):
             datetime(2019, 1, 14, 0, 1, 0, 0)
         ))
         self.assertTrue(croniter.match(
+            "0 0 * * * 1",
+            datetime(2023, 5, 25, 0, 0, 1, 0)
+        ))
+        self.assertFalse(croniter.match(
+            "0 0 * * * 1",
+            datetime(2023, 5, 25, 0, 0, 2, 0)
+        ))
+        self.assertTrue(croniter.match(
             "31 * * * *",
             datetime(2019, 1, 14, 1, 31, 0, 0)
         ))


### PR DESCRIPTION
Issue #29 was still bugging me: Croniter iterates fine for expressions with 6 positions, but the match method only matched on the minutes and not the seconds.

This should fix that, with tests included.