### PR TITLE
Add python 3.12 support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add Python 3.12 support [rafsaf]
 
 
 1.4.1 (2023-06-15)

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     packages=find_packages('src', exclude=['tests*', '*.tests*']),
     package_dir={'': 'src'},

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -227,7 +227,7 @@ class croniter(object):
         """
         Converts a UNIX timestamp `timestamp` into a `datetime` object.
         """
-        result = datetime.datetime.utcfromtimestamp(timestamp)
+        result = datetime.datetime.fromtimestamp(timestamp, tz=tzutc()).replace(tzinfo=None)
         if self.tzinfo:
             result = result.replace(tzinfo=tzutc()).astimezone(self.tzinfo)
 
@@ -851,7 +851,7 @@ def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude
     auto_rt = datetime.datetime
     # type is used in first if branch for perfs reasons
     if (
-        type(start) != type(stop) and not (
+        type(start) is not type(stop) and not (
             isinstance(start, type(stop)) or
             isinstance(stop, type(start)))
     ):
@@ -859,7 +859,7 @@ def croniter_range(start, stop, expr_format, ret_type=None, day_or=True, exclude
             "The start and stop must be same type.  {0} != {1}".
             format(type(start), type(stop)))
     if isinstance(start, (float, int)):
-        start, stop = (datetime.datetime.utcfromtimestamp(t) for t in (start, stop))
+        start, stop = (datetime.datetime.fromtimestamp(t, tzutc()).replace(tzinfo=None) for t in (start, stop))
         auto_rt = float
     if ret_type is None:
         ret_type = auto_rt

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -957,7 +957,7 @@ class CroniterTest(base.TestCase):
         dt = datetime(2019, 1, 14, 0, 0, 0, 0)
         for i in range(10):
             c = croniter("0 0 * * 2-4 *", start_time=dt)
-            dt = datetime.utcfromtimestamp(c.get_next())
+            dt = datetime.fromtimestamp(c.get_next(), dateutil.tz.tzutc()).replace(tzinfo=None)
             ret.append(dt)
             dt += timedelta(days=1)
         sret = ["{0}".format(r) for r in ret]
@@ -977,7 +977,7 @@ class CroniterTest(base.TestCase):
         dt = datetime(2019, 1, 14, 0, 0, 0, 0)
         for i in range(10):
             c = croniter("0 0 * * 1-7 *", start_time=dt)
-            dt = datetime.utcfromtimestamp(c.get_next())
+            dt = datetime.fromtimestamp(c.get_next(), dateutil.tz.tzutc()).replace(tzinfo=None)
             ret.append(dt)
             dt += timedelta(days=1)
         sret = ["{0}".format(r) for r in ret]
@@ -1000,7 +1000,7 @@ class CroniterTest(base.TestCase):
         for i in range(10):
             # c = croniter("0 0 * * Mon-Sun *", start_time=dt)
             c = croniter("0 0 * * Wed-Sun *", start_time=dt)
-            dt = datetime.utcfromtimestamp(c.get_next())
+            dt = datetime.fromtimestamp(c.get_next(), tz=dateutil.tz.tzutc()).replace(tzinfo=None)
             ret.append(dt)
             dt += timedelta(days=1)
         sret = ["{0}".format(r) for r in ret]

--- a/src/croniter/tests/test_croniter_hash.py
+++ b/src/croniter/tests/test_croniter_hash.py
@@ -191,7 +191,7 @@ class CroniterWordAliasTest(CroniterHashBase):
 
 
 class CroniterHashExpanderBase(base.TestCase):
-    def setUp(self) -> None:
+    def setUp(self):
         _rd = random.Random()
         _rd.seed(100)
         self.HASH_IDS = [

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     {py26,py27,py34,py35,py36,py37,py38,py39,py310,py311,py312}-std
     py27-coverage
 skipsdist = true
-requires = virtualenv<20.22.0
 
 [testenv]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 minversion = 2.3
 envlist =
-    {py26,py27,py34,py35,py36,py37,py38,py39,py310,py311}-std
+    {py26,py27,py34,py35,py36,py37,py38,py39,py310,py311,py312}-std
     py27-coverage
 skipsdist = true
+requires = virtualenv<20.22.0
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
Added python 3.12 around the project.

This will also fix https://github.com/kiorky/croniter/issues/49 with migration from utcfromtimestamp to fromtimestamp in backward compatible manner (hopefully). 
I was able to run tests with tox with py2.7 after above change, but had problems on ancient <=3.5, but this should be also ok.

Original deprecation warnings visible in tests include expected fix (discussion here https://discuss.python.org/t/deprecating-utcnow-and-utcfromtimestamp/26221):
```
src/croniter/tests/test_croniter.py: 1563 warnings
src/croniter/tests/test_croniter_hash.py: 138 warnings
src/croniter/tests/test_croniter_random.py: 18 warnings
src/croniter/tests/test_croniter_range.py: 2769 warnings
  /home/rafsaf/projects/croniter/src/croniter/croniter.py:230: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    result = datetime.datetime.utcfromtimestamp(timestamp)

src/croniter/tests/test_croniter.py: 10 warnings
  /home/rafsaf/projects/croniter/src/croniter/tests/test_croniter.py:1003: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    dt = datetime.utcfromtimestamp(c.get_next())

src/croniter/tests/test_croniter.py: 10 warnings
  /home/rafsaf/projects/croniter/src/croniter/tests/test_croniter.py:960: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    dt = datetime.utcfromtimestamp(c.get_next())

src/croniter/tests/test_croniter.py: 10 warnings
  /home/rafsaf/projects/croniter/src/croniter/tests/test_croniter.py:980: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    dt = datetime.utcfromtimestamp(c.get_next())

src/croniter/tests/test_croniter_range.py::CroniterRangeTest::test_auto_ret_type
src/croniter/tests/test_croniter_range.py::CroniterRangeTest::test_auto_ret_type
  /home/rafsaf/projects/croniter/src/croniter/croniter.py:862: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    start, stop = (datetime.datetime.utcfromtimestamp(t) for t in (start, stop))
```