### PR TITLE
Include LICENSE in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include *.txt *.cfg *.rst *.ini
+include *.txt *.cfg *.rst *.ini LICENSE
 
 recursive-include docs *
 recursive-include requirements *


### PR DESCRIPTION
Thanks for `croniter` and congratulations on `2.0.0`!

This PR just ensures the `LICENSE` file continues to be included in the sdist.