### PR TITLE
fix bug for bad case leap year 2 month 29 days;

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -396,7 +396,7 @@ class croniter(object):
                 if diff_month is not None and diff_month != 0:
                     if is_prev:
                         d += relativedelta(months=diff_month)
-                        reset_day = DAYS[d.month - 1]
+                        reset_day = days
                         d += relativedelta(
                             day=reset_day, hour=23, minute=59, second=59)
                     else:

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -396,7 +396,9 @@ class croniter(object):
                 if diff_month is not None and diff_month != 0:
                     if is_prev:
                         d += relativedelta(months=diff_month)
-                        reset_day = days
+                        reset_day = DAYS[d.month - 1]
+                        if d.month == 2 and self.is_leap(d.year) is True:
+                            reset_day += 1
                         d += relativedelta(
                             day=reset_day, hour=23, minute=59, second=59)
                     else:

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -132,6 +132,14 @@ class CroniterTest(base.TestCase):
         n4 = itr2.get_next(datetime)
         self.assertEqual(n4.day, 29)
         self.assertEqual(n4.month, 2)
+      
+    def testDay2(self):
+        base3 = datetime(2024, 2, 28)
+        itr2 = croniter('* * 29 2 *', base3)
+        n3 = itr2.get_prev(datetime)
+        self.assertEqual(n3.year, 2020)
+        self.assertEqual(n3.month, 2)
+        self.assertEqual(n3.day, 29)
 
     def testWeekDay(self):
         base = datetime(2010, 2, 25)


### PR DESCRIPTION
itr = croniter.croniter("* * 29 2 *", datetime.datetime(2024, 2, 28, 0, 0, 0))
itr.get_prev(datetime.datime)
raise Error 
croniter.croniter.CroniterBadDateError: failed to find prev date