### PR TITLE
Supports str hash_id in is_valid() as in __init__()

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -824,6 +824,11 @@ class croniter(object):
 
     @classmethod
     def is_valid(cls, expression, hash_id=None):
+        if hash_id:
+            if not isinstance(hash_id, (bytes, str)):
+                raise TypeError('hash_id must be bytes or UTF-8 string')
+            if not isinstance(hash_id, bytes):
+                hash_id = hash_id.encode('UTF-8')
         try:
             cls.expand(expression, hash_id=hash_id)
         except CroniterError:


### PR DESCRIPTION
Before:
```
>>> croniter.is_valid('H 0 * * *', hash_id='abc')
Traceback (most recent call last):
...
TypeError: a bytes-like object is required, not 'str'
```

After:
```
>>> croniter.is_valid('H 0 * * *', hash_id='abc')
True
```