### PR TITLE
ensure match return false when not time available

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -929,12 +929,15 @@ class croniter(object):
                     day_or=True, second_at_beginning=False):
         cron = cls(cron_expression, to_datetime, ret_type=datetime.datetime,
                    day_or=day_or, second_at_beginning=second_at_beginning)
-        td, ms1 = cron.get_current(datetime.datetime), relativedelta(microseconds=1)
-        if not td.microsecond:
-            td = td + ms1
-        cron.set_current(td, force=True)
-        tdp, tdt = cron.get_current(), cron.get_prev()
-        precision_in_seconds = 1 if len(cron.expanded) == 6 else 60
+        tdp = cron.get_current(datetime.datetime)
+        if not tdp.microsecond:
+            tdp += relativedelta(microseconds=1)
+        cron.set_current(tdp, force=True)
+        try:
+            tdt = cron.get_prev()
+        except CroniterBadDateError:
+            return False
+        precision_in_seconds = 1 if len(cron.expanded) > UNIX_CRON_LEN else 60
         duration_in_second = (to_datetime - from_datetime).total_seconds() + precision_in_seconds
         return (max(tdp, tdt) - min(tdp, tdt)).total_seconds() < duration_in_second
 

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1088,6 +1088,14 @@ class CroniterTest(base.TestCase):
             day_or=False
         ))
 
+    def test_match_handle_bad_cron(self):
+        # some cron expression can't get prev value and should not raise exception
+        self.assertFalse(croniter.match(
+            '0 0 31 1 1#1',
+            datetime(2020, 1, 31),
+            day_or=False
+        ))
+
     def test_match_range(self):
         self.assertTrue(croniter.match_range(
             "0 0 * * *",


### PR DESCRIPTION
currently if no previous is available, it will raise exception instead of false