### PR TITLE
Remove unnecessary `or self._ret_type`

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -289,13 +289,13 @@ class croniter(object):
     def get_next(self, ret_type=None, start_time=None, update_current=True):
         if start_time and self._expand_from_start_time:
             raise ValueError("start_time is not supported when using expand_from_start_time = True.")
-        return self._get_next(ret_type or self._ret_type,
+        return self._get_next(ret_type=ret_type,
                               start_time=start_time,
                               is_prev=False,
                               update_current=update_current)
 
     def get_prev(self, ret_type=None, start_time=None, update_current=True):
-        return self._get_next(ret_type or self._ret_type,
+        return self._get_next(ret_type=ret_type,
                               start_time=start_time,
                               is_prev=True,
                               update_current=update_current)
@@ -445,7 +445,7 @@ class croniter(object):
         try:
             while True:
                 self._is_prev = False
-                yield self._get_next(ret_type or self._ret_type,
+                yield self._get_next(ret_type=ret_type,
                                      start_time=start_time, update_current=update_current)
                 start_time = None
         except CroniterBadDateError:
@@ -459,7 +459,7 @@ class croniter(object):
         try:
             while True:
                 self._is_prev = True
-                yield self._get_next(ret_type or self._ret_type,
+                yield self._get_next(ret_type=ret_type,
                                      start_time=start_time, update_current=update_current)
                 start_time = None
         except CroniterBadDateError:


### PR DESCRIPTION
We already do this in the `_get_next` function body here https://github.com/kiorky/croniter/blob/010b321f6106df798032264df1a180fc3cc18407/src/croniter/croniter.py#L362