### PR TITLE
Remove unused call to `sys.exc_info`

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1033,7 +1033,6 @@ class croniter(object):
                                second_at_beginning=second_at_beginning,
                                from_timestamp=from_timestamp)
         except (ValueError,) as exc:
-            error_type, error_instance, traceback = sys.exc_info()
             if isinstance(exc, CroniterError):
                 raise
             if int(sys.version[0]) >= 3:


### PR DESCRIPTION
None of the return values were being used