### PR TITLE
Remove unused `ALPHAS`

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -79,10 +79,7 @@ EPOCH = datetime.datetime.fromtimestamp(0)
 M_ALPHAS = {'jan': 1, 'feb': 2, 'mar': 3, 'apr': 4, 'may': 5, 'jun': 6,
             'jul': 7, 'aug': 8, 'sep': 9, 'oct': 10, 'nov': 11, 'dec': 12}
 DOW_ALPHAS = {'sun': 0, 'mon': 1, 'tue': 2, 'wed': 3, 'thu': 4, 'fri': 5, 'sat': 6}
-ALPHAS = {}
-for i in M_ALPHAS, DOW_ALPHAS:
-    ALPHAS.update(i)
-del i
+
 step_search_re = re.compile(r'^([^-]+)-([^-/]+)(/(\d+))?$')
 only_int_re = re.compile(r'^\d+$')
 


### PR DESCRIPTION
This appears to be completely unused. If it is being declared to be exported as part of a public API, it's unclear why.