### PR TITLE
black: Add black to project

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/setup-python@v5
       with: {python-version: "${{ matrix.python-version }}", cache: pip, cache-dependency-path: 'requirements/*.txt'}
     - name: install tests dependencies
-      run: pip install -r requirements/test.txt -r requirements/lint.txt -r requirements/tox.txt 
+      run: pip install -r requirements/test.txt -r requirements/lint.txt -r requirements/tox.txt
     - name: run lint
       run: tox --current-env -e lint
     - name: run tests with coverage
@@ -70,3 +70,22 @@ jobs:
          docker compose run --rm app tox --current-env -e test
       env: {COMPOSE_FILE: "docker-compose.yml:docker-compose-32bits.yml"}
 
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Cache tox environments
+      uses: actions/cache@v4
+      with:
+        path: .tox
+        key: ${{ runner.os }}-3.13-tox
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+        cache: pip
+        cache-dependency-path: 'requirements/*.txt'
+    - name: install format dependencies
+      run: pip install -r requirements/format.txt -r requirements/tox.txt
+    - name: run format
+      run: tox --current-env -e check-format

--- a/README.rst
+++ b/README.rst
@@ -340,8 +340,9 @@ Develop this package
     git clone https://github.com/kiorky/croniter.git
     cd croniter
     virtualenv --no-site-packages venv3
-    venv3/bin/pip install --upgrade -r requirements/test.txt -r requirements/lint.txt -r requirements/tox.txt
+    venv3/bin/pip install --upgrade -r requirements/test.txt -r requirements/lint.txt -r requirements/format.txt -r requirements/tox.txt
     venv3/bin/tox --current-env -e lint,test
+    venv3/bin/black src/
 
 
 Testing under py2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+line-length = 119
+target-version = [
+  # XXX: This project does still support 2.6, but black does not have a 2.6
+  # target. There should be very few (if any) syntax differences between the
+  # two versions however.
+  'py27',
+  'py34',
+  'py35',
+  'py36',
+  'py37',
+  'py38',
+  'py39',
+  'py310',
+  # Because we're using an old version of black to support older python, there
+  # is no explicit python version target past 3.10
+]

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -1,0 +1,8 @@
+# We lock to the version just before black 22, as this is when python 2 support
+# is dropped.
+black==21.11b1
+
+# Lock to an older version of click to fix
+# https://github.com/psf/black/issues/2964. This was fixed in a newever version
+# of black that we cannot use.
+click==8.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,7 @@ deps = -r{toxinidir}/requirements/lint.txt
 changedir = src
 commands = flake8 croniter/croniter.py
 
+[testenv:check-format]
+deps = -r{toxinidir}/requirements/format.txt
+changedir = src
+commands = black --check .


### PR DESCRIPTION
- Adds black to CI workflow
- Adds a new tox `format` command
- Locks black to the last version supporting python 2
- Configures black using pyproject.toml (unfortunately it cannot be configured using tox.ini, see https://github.com/psf/black/issues/2172)

Please don't merge yet until I've merged all the PRs to complete formatting of the project. The PR should fail before then!

Part of #99 