### PR TITLE
Remove unused OVERFLOW32B_MODE from tests

### DIFF
--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -10,7 +10,6 @@ import dateutil.tz
 import pytz
 
 from croniter import (
-    OVERFLOW32B_MODE,
     CroniterBadCronError,
     CroniterBadDateError,
     CroniterNotAlphaError,


### PR DESCRIPTION
This module constnat is not used