### PR TITLE
Stop supporting Python < 3.9

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,27 +11,6 @@ env:
   RELEASABLE_REPOS: "^kiorky/"
   RELEASABLE_BRANCHES: "^(refs/heads/)?(master|main|new-packaging)$"
 jobs:
-  test-py2:
-    runs-on: ubuntu-latest
-    strategy: {fail-fast: false}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Cache tox environments
-      uses: actions/cache@v4
-      with:
-        path: .cache
-        key: ${{ runner.os }}-py27
-    - name: install dependencies && test on py27
-      run: |
-        set -ex
-        export PIP_CACHE_DIR=$(pwd)/.cache/pip;export PIP_DOWNLOAD_CACHE=$PIP_CACHE_DIR
-        mkdir -pv $PIP_CACHE_DIR || true
-        sudo apt update && sudo apt install -y python2.7
-        mkdir venv2 && curl -sSL "https://github.com/pypa/get-virtualenv/blob/20.27.0/public/2.7/virtualenv.pyz?raw=true" > venv2/venv && python2.7 venv2/venv venv2
-        # we need the latest py2 compatible pytest which is not the latest available
-        venv2/bin/python2 -m pip install pytest -r <(grep -v pytest ./requirements/base.txt)
-        venv2/bin/pytest src
-
   test-code-QA:
     runs-on: ubuntu-latest
     strategy:
@@ -58,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Cache tox environments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,6 @@
 [tool.black]
 line-length = 119
 target-version = [
-  # XXX: This project does still support 2.6, but black does not have a 2.6
-  # target. There should be very few (if any) syntax differences between the
-  # two versions however.
-  'py27',
-  'py34',
-  'py35',
-  'py36',
-  'py37',
-  'py38',
   'py39',
   'py310',
   # Because we're using an old version of black to support older python, there

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,5 @@
 pytest>=8.3.3
 pytest-cov>=5.0.0
 coverage>=4.2
-mock>=2.0.0  # For Python 2
 flake8
 setuptools

--- a/src/croniter/__init__.py
+++ b/src/croniter/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from . import croniter as cron_m
 from .croniter import (
     DAY_FIELD,

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -754,7 +754,7 @@ class CroniterTest(base.TestCase):
         for expected_date, expected_offset in expected_schedule:
             d = callback()
             self.assertEqual(expected_date, d.replace(tzinfo=None))
-            self.assertEqual(expected_offset, croniter._timedelta_to_seconds(d.utcoffset()))
+            self.assertEqual(expected_offset, d.utcoffset().total_seconds())
 
     def testTimezoneWinterTime(self):
         tz = pytz.timezone("Europe/Athens")


### PR DESCRIPTION
Everything else is out of support. This will be released as a major version
bump to go along with the change of home to pallets-eco.

For now I've left the 32bit support in, but maybe that doesn't make sense to keep longer term? The cost isn't large tbf
