### PR TITLE
Further modernize the codebase

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -10,7 +10,6 @@ import re
 import struct
 import sys
 import traceback as _traceback
-from collections import OrderedDict
 from time import time
 
 from dateutil.relativedelta import relativedelta
@@ -1298,8 +1297,4 @@ class HashExpander:
         )
 
 
-EXPANDERS = OrderedDict(
-    [
-        ("hash", HashExpander),
-    ]
-)
+EXPANDERS = {"hash": HashExpander}


### PR DESCRIPTION
Small updates for the supported Python versions.
- since Python 3.7 `dict` is guaranteed to keep the insertion order, so no need for `OrderedDict` (and a py2 fallback)
- ~~`pytz` was used only as a py2 fallback, so I removed the dependency and corrected the code.~~ I see that dropping `pytz` is being handled in #155, so I am not going to try to duplicate the work.