### PR TITLE
Drop unittest2

### DIFF
--- a/src/croniter/tests/base.py
+++ b/src/croniter/tests/base.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 class TestCase(unittest.TestCase):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
+import unittest
 from datetime import datetime, timedelta
 from functools import partial
 from time import sleep

--- a/src/croniter/tests/test_croniter_dst_repetition.py
+++ b/src/croniter/tests/test_croniter_dst_repetition.py
@@ -4,13 +4,9 @@ All related DST croniter tests are isolated here.
 """
 # -*- coding: utf-8 -*-
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 import os
 import time
+import unittest
 from collections import OrderedDict
 from datetime import datetime, timedelta
 

--- a/src/croniter/tests/test_croniter_hash.py
+++ b/src/croniter/tests/test_croniter_hash.py
@@ -1,11 +1,6 @@
 import random
+import unittest
 import uuid
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 from datetime import datetime, timedelta
 
 from croniter import CroniterBadCronError, CroniterNotAlphaError, croniter

--- a/src/croniter/tests/test_croniter_random.py
+++ b/src/croniter/tests/test_croniter_random.py
@@ -1,8 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
+import unittest
 from datetime import datetime, timedelta
 
 from croniter import croniter

--- a/src/croniter/tests/test_croniter_speed.py
+++ b/src/croniter/tests/test_croniter_speed.py
@@ -2,13 +2,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 import os
 import sys
+import unittest
 from datetime import datetime
 from timeit import Timer
 


### PR DESCRIPTION
unittest2 is a backport of the Python 3 unittest module. Since Python 2 support was dropped, drop the support for `unittest2`.