### PR TITLE
Let _calc take a datetime object instead of a timestamp

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -481,10 +481,10 @@ class croniter:
             sign = 1
             offset = 1 if (len(expanded) > UNIX_CRON_LEN) else 60
 
-        dst = now = self.timestamp_to_datetime(now + sign * offset)
+        dst = self.timestamp_to_datetime(now + sign * offset)
 
-        month, year = dst.month, dst.year
-        current_year = now.year
+        month = dst.month
+        year = current_year = dst.year
 
         def proc_year(d):
             if len(expanded) == YEAR_CRON_LEN:

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -470,18 +470,18 @@ class croniter:
         return self._calc(self.cur, expanded, nth_weekday_of_month, is_prev)
 
     def _calc(self, now, expanded, nth_weekday_of_month, is_prev):
+        now = self.timestamp_to_datetime(now)
         if is_prev:
-            now = math.ceil(now)
             nearest_diff_method = self._get_prev_nearest_diff
-            sign = -1
-            offset = 1 if (len(expanded) > UNIX_CRON_LEN or now % 60 > 0) else 60
+            offset = relativedelta(microseconds=-1)
         else:
-            now = math.floor(now)
             nearest_diff_method = self._get_next_nearest_diff
-            sign = 1
-            offset = 1 if (len(expanded) > UNIX_CRON_LEN) else 60
-
-        dst = self.timestamp_to_datetime(now + sign * offset)
+            offset = relativedelta(seconds=1) if len(expanded) > UNIX_CRON_LEN else relativedelta(minutes=1)
+        dst = now + offset
+        if len(expanded) > UNIX_CRON_LEN:
+            dst = dst.replace(microsecond=0)
+        else:
+            dst = dst.replace(second=0, microsecond=0)
 
         month = dst.month
         year = current_year = dst.year


### PR DESCRIPTION
Let `_calc` take and return a datetime object instead of a timestamp. This is a preparation of fixing the DST handling which will need to operate on non-existing wall times.