### PR TITLE
test: fix date in test_dst_iter

### DIFF
--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1235,7 +1235,7 @@ class CroniterTest(base.TestCase):
     def test_dst_iter(self):
         """Test Hebron jumps one hour forward on 2022-03-27 00:00 (UTC+2 -> UTC+3)."""
         tz = pytz.timezone("Asia/Hebron")
-        now = datetime(2022, 3, 26, 0, 0, 0, tzinfo=tz)
+        now = tz.localize(datetime(2022, 3, 25, 0, 0, 0))
         it = croniter("0 0 * * *", now)
         ret = [
             it.get_next(datetime).isoformat(),


### PR DESCRIPTION
pytz requires to use `localize()` to convert a local time to a timezone aware time. Setting `tzinfo` leads to a wrong result:

```python3
>>> import datetime, pytz
>>> datetime.datetime(2022, 3, 26, 0, 0, 0, tzinfo=pytz.timezone("Asia/Hebron"))
datetime.datetime(2022, 3, 26, 0, 0, tzinfo=<DstTzInfo 'Asia/Hebron' LMT+2:20:00 STD>)
```

So `now` is 2022-03-25T23:40:00+02:20 instead of 2022-03-26T00:00:00+02:00 (and UTC+02:20 is incorrect).

So use `localize()` and use a date that is before 2022-03-26.