### PR TITLE
Fix all flake8 complaints

### DIFF
--- a/src/croniter/__init__.py
+++ b/src/croniter/__init__.py
@@ -19,4 +19,23 @@ from .croniter import (
     datetime_to_timestamp,
 )
 
-croniter.__name__  # make flake8 happy
+__all__ = [
+    "DAY_FIELD",
+    "HOUR_FIELD",
+    "MINUTE_FIELD",
+    "MONTH_FIELD",
+    "OVERFLOW32B_MODE",
+    "SECOND_FIELD",
+    "UTC_DT",
+    "YEAR_FIELD",
+    "CroniterBadCronError",
+    "CroniterBadDateError",
+    "CroniterBadTypeRangeError",
+    "CroniterError",
+    "CroniterNotAlphaError",
+    "CroniterUnsupportedSyntaxError",
+    "cron_m",
+    "croniter",
+    "croniter_range",
+    "datetime_to_timestamp",
+]

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1252,7 +1252,9 @@ class CroniterTest(base.TestCase):
         )
 
     def test_nth_wday_simple(self):
-        f = lambda y, m, w: croniter._get_nth_weekday_of_month(y, m, w)
+        def f(y, m, w):
+            return croniter._get_nth_weekday_of_month(y, m, w)
+
         sun, mon, tue, wed, thu, fri, sat = range(7)
 
         self.assertEqual(f(2000, 1, mon), (3, 10, 17, 24, 31))
@@ -1263,7 +1265,9 @@ class CroniterTest(base.TestCase):
         self.assertEqual(f(2000, 2, sat), (5, 12, 19, 26))
 
     def test_nth_as_last_wday_simple(self):
-        f = lambda y, m, w: croniter._get_nth_weekday_of_month(y, m, w)[-1]
+        def f(y, m, w):
+            return croniter._get_nth_weekday_of_month(y, m, w)[-1]
+
         sun, mon, tue, wed, thu, fri, sat = range(7)
         self.assertEqual(f(2000, 2, tue), 29)
         self.assertEqual(f(2000, 2, sun), 27)
@@ -1274,7 +1278,9 @@ class CroniterTest(base.TestCase):
         self.assertEqual(f(2000, 2, sat), 26)
 
     def test_wdom_core_leap_year(self):
-        f = lambda y, m, w: croniter._get_nth_weekday_of_month(y, m, w)[-1]
+        def f(y, m, w):
+            return croniter._get_nth_weekday_of_month(y, m, w)[-1]
+
         sun, mon, tue, wed, thu, fri, sat = range(7)
         self.assertEqual(f(2000, 2, tue), 29)
         self.assertEqual(f(2000, 2, sun), 27)
@@ -1413,7 +1419,8 @@ class CroniterTest(base.TestCase):
             self.assertListEqual(getn(cron_c, 5), expect_c)
 
     def test_lwom_mixup_all_fri_last_sat(self):
-        # Based on the failure of test_hash_mixup_all_fri_3rd_sat, we should expect this to fail too as this implementation simply extends nth_weekday_of_month
+        # Based on the failure of test_hash_mixup_all_fri_3rd_sat, we should expect
+        # this to fail too as this implementation simply extends nth_weekday_of_month
         cron_a = "0 0 * * L6"
         cron_b = "0 0 * * 5"
         cron_c = "0 0 * * 5,L6"
@@ -1717,7 +1724,8 @@ class CroniterTest(base.TestCase):
         start = datetime(2020, 9, 24)
         cron = "0 13 8 1,4,7,10 wed"
 
-        # Expect exception because no explicit range was provided.  Therefore, the caller should be made aware that an implicit limit was hit.
+        # Expect exception because no explicit range was provided.  Therefore, the
+        # caller should be made aware that an implicit limit was hit.
         ccron = croniter(cron, start, day_or=False)
         ccron._max_years_between_matches = 1
         iterable = ccron.all_next()
@@ -1728,7 +1736,8 @@ class CroniterTest(base.TestCase):
         n = next(iterable)
         self.assertEqual(n, datetime(2025, 1, 8, 13))
 
-        # If the explicitly given lookahead isn't enough to reach the next date, that's fine.  The caller specified the maximum gap, so no just stop iteration
+        # If the explicitly given lookahead isn't enough to reach the next date, that's fine.
+        # The caller specified the maximum gap, so no just stop iteration
         iterable = croniter(cron, start, day_or=False, max_years_between_matches=2).all_next(datetime)
         with self.assertRaises(StopIteration):
             next(iterable)

--- a/src/croniter/tests/test_croniter_speed.py
+++ b/src/croniter/tests/test_croniter_speed.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import sys
 import unittest
 from datetime import datetime
 from timeit import Timer

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ commands =
 
 [testenv:lint]
 deps = -r{toxinidir}/requirements/lint.txt
-changedir = src
-commands = flake8 croniter/croniter.py
+commands = flake8 .
 
 [testenv:mypy]
 deps = -r{toxinidir}/requirements/mypy.txt


### PR DESCRIPTION
The CI currently only checks `src/croniter/croniter.py` for flake8, but there are more Python files that should be checked.

```
$ flake8 .
./src/croniter/__init__.py:1:1: F401 '.croniter as cron_m' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.DAY_FIELD' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.HOUR_FIELD' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.MINUTE_FIELD' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.MONTH_FIELD' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.OVERFLOW32B_MODE' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.SECOND_FIELD' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.UTC_DT' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.YEAR_FIELD' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.CroniterBadCronError' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.CroniterBadDateError' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.CroniterBadTypeRangeError' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.CroniterError' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.CroniterNotAlphaError' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.CroniterUnsupportedSyntaxError' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.croniter_range' imported but unused
./src/croniter/__init__.py:2:1: F401 '.croniter.datetime_to_timestamp' imported but unused
./src/croniter/tests/test_croniter.py:1255:9: E731 do not assign a lambda expression, use a def
./src/croniter/tests/test_croniter.py:1266:9: E731 do not assign a lambda expression, use a def
./src/croniter/tests/test_croniter.py:1277:9: E731 do not assign a lambda expression, use a def
./src/croniter/tests/test_croniter.py:1416:121: E501 line too long (159 > 120 characters)
./src/croniter/tests/test_croniter.py:1720:121: E501 line too long (142 > 120 characters)
./src/croniter/tests/test_croniter.py:1731:121: E501 line too long (158 > 120 characters)
./src/croniter/tests/test_croniter_speed.py:4:1: F401 'sys' imported but unused
```

Fix all flake8 complaints and change the CI to check all Python files.