### PR TITLE
Reduce line length to 99

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ exclude = ["croniter.tests*"]
 croniter = ["tests*"]
 
 [tool.black]
-line-length = 119
+line-length = 99
 target-version = [
   'py39',
   'py310',
@@ -61,4 +61,4 @@ target-version = [
 ]
 
 [tool.pylint.format]
-max-line-length = 119
+max-line-length = 99

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 120
+max-line-length = 99
 ignore = C901,W504,W503
 
 [coverage:run]
@@ -24,4 +24,4 @@ skip = .tox,.git
 force_grid_wrap = 0
 use_parentheses = True
 ensure_newline_before_comments = True
-line_length = 119
+line_length = 99

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -70,6 +70,7 @@ M_ALPHAS: dict[str, Union[int, str]] = {
 DOW_ALPHAS: dict[str, Union[int, str]] = {
     "sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6
 }
+# fmt: on
 
 MINUTE_FIELD = 0
 HOUR_FIELD = 1
@@ -79,10 +80,17 @@ DOW_FIELD = 4
 SECOND_FIELD = 5
 YEAR_FIELD = 6
 
-UNIX_FIELDS =   (MINUTE_FIELD, HOUR_FIELD, DAY_FIELD, MONTH_FIELD, DOW_FIELD)  # noqa: E222
-SECOND_FIELDS = (MINUTE_FIELD, HOUR_FIELD, DAY_FIELD, MONTH_FIELD, DOW_FIELD, SECOND_FIELD)  # noqa: E222
-YEAR_FIELDS =   (MINUTE_FIELD, HOUR_FIELD, DAY_FIELD, MONTH_FIELD, DOW_FIELD, SECOND_FIELD, YEAR_FIELD)  # noqa: E222
-# fmt: on
+UNIX_FIELDS = (MINUTE_FIELD, HOUR_FIELD, DAY_FIELD, MONTH_FIELD, DOW_FIELD)
+SECOND_FIELDS = (MINUTE_FIELD, HOUR_FIELD, DAY_FIELD, MONTH_FIELD, DOW_FIELD, SECOND_FIELD)
+YEAR_FIELDS = (
+    MINUTE_FIELD,
+    HOUR_FIELD,
+    DAY_FIELD,
+    MONTH_FIELD,
+    DOW_FIELD,
+    SECOND_FIELD,
+    YEAR_FIELD,
+)
 
 step_search_re = re.compile(r"^([^-]+)-([^-/]+)(/(\d+))?$")
 only_int_re = re.compile(r"^\d+$")
@@ -92,7 +100,8 @@ WEEKDAYS = "|".join(DOW_ALPHAS.keys())
 MONTHS = "|".join(M_ALPHAS.keys())
 star_or_int_re = re.compile(r"^(\d+|\*)$")
 special_dow_re = re.compile(
-    rf"^(?P<pre>((?P<he>(({WEEKDAYS})(-({WEEKDAYS}))?)|(({MONTHS})(-({MONTHS}))?)|\w+)#)|l)(?P<last>\d+)$"
+    rf"^(?P<pre>((?P<he>(({WEEKDAYS})(-({WEEKDAYS}))?)"
+    rf"|(({MONTHS})(-({MONTHS}))?)|\w+)#)|l)(?P<last>\d+)$"
 )
 re_star = re.compile("[*]")
 hash_expression_re = re.compile(
@@ -169,15 +178,7 @@ class croniter:
 
     # This helps with expanding `*` fields into `lower-upper` ranges. Each item
     # in this tuple maps to the corresponding field index
-    RANGES = (
-        (0, 59),
-        (0, 23),
-        (1, 31),
-        (1, 12),
-        (0, 6),
-        (0, 59),
-        (1970, 2099),
-    )
+    RANGES = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 6), (0, 59), (1970, 2099))
 
     ALPHACONV: tuple[dict[str, Union[int, str]], ...] = (
         {},  # 0: min
@@ -193,25 +194,9 @@ class croniter:
         {},
     )
 
-    LOWMAP: tuple[dict[int, int], ...] = (
-        {},
-        {},
-        {0: 1},
-        {0: 1},
-        {7: 0},
-        {},
-        {},
-    )
+    LOWMAP: tuple[dict[int, int], ...] = ({}, {}, {0: 1}, {0: 1}, {7: 0}, {}, {})
 
-    LEN_MEANS_ALL = (
-        60,
-        24,
-        31,
-        12,
-        7,
-        60,
-        130,
-    )
+    LEN_MEANS_ALL = (60, 24, 31, 12, 7, 60, 130)
 
     def __init__(
         self,
@@ -272,20 +257,16 @@ class croniter:
 
     def get_next(self, ret_type=None, start_time=None, update_current=True):
         if start_time and self._expand_from_start_time:
-            raise ValueError("start_time is not supported when using expand_from_start_time = True.")
+            raise ValueError(
+                "start_time is not supported when using expand_from_start_time = True."
+            )
         return self._get_next(
-            ret_type=ret_type,
-            start_time=start_time,
-            is_prev=False,
-            update_current=update_current,
+            ret_type=ret_type, start_time=start_time, is_prev=False, update_current=update_current
         )
 
     def get_prev(self, ret_type=None, start_time=None, update_current=True):
         return self._get_next(
-            ret_type=ret_type,
-            start_time=start_time,
-            is_prev=True,
-            update_current=update_current,
+            ret_type=ret_type, start_time=start_time, is_prev=True, update_current=update_current
         )
 
     def get_current(self, ret_type=None):
@@ -342,13 +323,7 @@ class croniter:
 
     _timestamp_to_datetime = timestamp_to_datetime  # retrocompat
 
-    def _get_next(
-        self,
-        ret_type=None,
-        start_time=None,
-        is_prev=None,
-        update_current=None,
-    ):
+    def _get_next(self, ret_type=None, start_time=None, is_prev=None, update_current=None):
         if update_current is None:
             update_current = True
         self.set_current(start_time, force=True)
@@ -404,14 +379,13 @@ class croniter:
         May be used instead of an implicit call to __iter__ whenever a
         non-default `ret_type` needs to be specified.
         """
-        # In a Python 3.7+ world:  contextlib.suppress and contextlib.nullcontext could be used instead
+        # In a Python 3.7+ world:  contextlib.suppress and contextlib.nullcontext could
+        # be used instead
         try:
             while True:
                 self._is_prev = False
                 yield self._get_next(
-                    ret_type=ret_type,
-                    start_time=start_time,
-                    update_current=update_current,
+                    ret_type=ret_type, start_time=start_time, update_current=update_current
                 )
                 start_time = None
         except CroniterBadDateError:
@@ -427,9 +401,7 @@ class croniter:
             while True:
                 self._is_prev = True
                 yield self._get_next(
-                    ret_type=ret_type,
-                    start_time=start_time,
-                    update_current=update_current,
+                    ret_type=ret_type, start_time=start_time, update_current=update_current
                 )
                 start_time = None
         except CroniterBadDateError:
@@ -452,14 +424,16 @@ class croniter:
 
         # exception to support day of month and day of week as defined in cron
         if (expanded[DAY_FIELD][0] != "*" and expanded[DOW_FIELD][0] != "*") and self._day_or:
-            # If requested, handle a bug in vixie cron/ISC cron where day_of_month and day_of_week form
-            # an intersection (AND) instead of a union (OR) if either field is an asterisk or starts with an asterisk
-            # (https://crontab.guru/cron-bug.html)
+            # If requested, handle a bug in vixie cron/ISC cron where day_of_month and
+            # day_of_week form an intersection (AND) instead of a union (OR) if either
+            # field is an asterisk or starts with an asterisk (https://crontab.guru/cron-bug.html)
             if self._implement_cron_bug and (
-                re_star.match(self.expressions[DAY_FIELD]) or re_star.match(self.expressions[DOW_FIELD])
+                re_star.match(self.expressions[DAY_FIELD])
+                or re_star.match(self.expressions[DOW_FIELD])
             ):
-                # To produce a schedule identical to the cron bug, we'll bypass the code that
-                # makes a union of DOM and DOW, and instead skip to the code that does an intersect instead
+                # To produce a schedule identical to the cron bug, we'll bypass the code
+                # that makes a union of DOM and DOW, and instead skip to the code that
+                # does an intersect instead
                 pass
             else:
                 bak = expanded[DOW_FIELD]
@@ -512,21 +486,11 @@ class croniter:
                     if diff_year != 0:
                         if is_prev:
                             d += relativedelta(
-                                years=diff_year,
-                                month=12,
-                                day=31,
-                                hour=23,
-                                minute=59,
-                                second=59,
+                                years=diff_year, month=12, day=31, hour=23, minute=59, second=59
                             )
                         else:
                             d += relativedelta(
-                                years=diff_year,
-                                month=1,
-                                day=1,
-                                hour=0,
-                                minute=0,
-                                second=0,
+                                years=diff_year, month=1, day=1, hour=0, minute=0, second=0
                             )
                         return True, d
             return False, d
@@ -535,7 +499,9 @@ class croniter:
             try:
                 expanded[MONTH_FIELD].index("*")
             except ValueError:
-                diff_month = nearest_diff_method(d.month, expanded[MONTH_FIELD], self.MONTHS_IN_YEAR)
+                diff_month = nearest_diff_method(
+                    d.month, expanded[MONTH_FIELD], self.MONTHS_IN_YEAR
+                )
                 reset_day = 1
 
                 if diff_month is not None and diff_month != 0:
@@ -544,7 +510,9 @@ class croniter:
                         reset_day = _last_day_of_month(d.year, d.month)
                         d += relativedelta(day=reset_day, hour=23, minute=59, second=59)
                     else:
-                        d += relativedelta(months=diff_month, day=reset_day, hour=0, minute=0, second=0)
+                        d += relativedelta(
+                            months=diff_month, day=reset_day, hour=0, minute=0, second=0
+                        )
                     return True, d
             return False, d
 
@@ -764,7 +732,8 @@ class croniter:
             if c <= range_val:
                 candidate = c
                 break
-        # fix crontab "0 6 30 3 *" condidates only a element, then get_prev error return 2021-03-02 06:00:00
+        # fix crontab "0 6 30 3 *" condidates only a element, then get_prev error
+        # return 2021-03-02 06:00:00
         if candidate > range_val:
             return -range_val
         return candidate - x - range_val
@@ -790,19 +759,16 @@ class croniter:
             # but still let conversion happen if day field is shifted
             (field_index in [DAY_FIELD, MONTH_FIELD] and len_expressions == UNIX_CRON_LEN)
             or (field_index in [MONTH_FIELD, DOW_FIELD] and len_expressions == SECOND_CRON_LEN)
-            or (field_index in [DAY_FIELD, MONTH_FIELD, DOW_FIELD] and len_expressions == YEAR_CRON_LEN)
+            or (
+                field_index in [DAY_FIELD, MONTH_FIELD, DOW_FIELD]
+                and len_expressions == YEAR_CRON_LEN
+            )
         ):
             val = cls.LOWMAP[field_index][val]
         return val
 
     @classmethod
-    def _expand(
-        cls,
-        expr_format,
-        hash_id=None,
-        second_at_beginning=False,
-        from_timestamp=None,
-    ):
+    def _expand(cls, expr_format, hash_id=None, second_at_beginning=False, from_timestamp=None):
         # Split the expression in components, and normalize L -> l, MON -> mon,
         # etc. Keep expr_format untouched so we can use it in the exception
         # messages.
@@ -826,7 +792,9 @@ class croniter:
         expressions = efl.split()
 
         if len(expressions) not in VALID_LEN_EXPRESSION:
-            raise CroniterBadCronError("Exactly 5, 6 or 7 columns has to be specified for iterator expression.")
+            raise CroniterBadCronError(
+                "Exactly 5, 6 or 7 columns has to be specified for iterator expression."
+            )
 
         if len(expressions) > UNIX_CRON_LEN and second_at_beginning:
             # move second to it's own(6th) field to process by same logical
@@ -838,17 +806,14 @@ class croniter:
         for field_index, expr in enumerate(expressions):
             for expanderid, expander in EXPANDERS.items():
                 expr = expander(cls).expand(
-                    efl,
-                    field_index,
-                    expr,
-                    hash_id=hash_id,
-                    from_timestamp=from_timestamp,
+                    efl, field_index, expr, hash_id=hash_id, from_timestamp=from_timestamp
                 )
 
             if "?" in expr:
                 if expr != "?":
                     raise CroniterBadCronError(
-                        f"[{expr_format}] is not acceptable. Question mark can not used with other characters"
+                        f"[{expr_format}] is not acceptable."
+                        f" Question mark can not used with other characters"
                     )
                 if field_index not in [DAY_FIELD, DOW_FIELD]:
                     raise CroniterBadCronError(
@@ -878,7 +843,8 @@ class croniter:
                                 assert 5 >= nth >= 1
                             except (KeyError, ValueError, AssertionError):
                                 raise CroniterBadCronError(
-                                    f"[{expr_format}] is not acceptable. Invalid day_of_week value: '{nth}'"
+                                    f"[{expr_format}] is not acceptable."
+                                    f" Invalid day_of_week value: '{nth}'"
                                 )
                         elif last:
                             e = last
@@ -897,11 +863,7 @@ class croniter:
                     # Before matching step_search_re,
                     # normalize "{start}/{step}" to "{start}-{max}/{step}".
                     # Example: in the minute field, "10/5" normalizes to "10-59/5"
-                    t = re.sub(
-                        r"^(.+)\/(.+)$",
-                        r"\1-%d/\2" % (cls.RANGES[field_index][1]),
-                        str(e),
-                    )
+                    t = re.sub(r"^(.+)\/(.+)$", r"\1-%d/\2" % (cls.RANGES[field_index][1]), str(e))
                     m = step_search_re.search(t)
 
                 if m:
@@ -916,36 +878,42 @@ class croniter:
                     if not only_int_re.search(high):
                         high = str(cls._alphaconv(field_index, high, expressions))
 
-                    # normally, it's already guarded by the RE that should not accept not-int values.
+                    # normally, it's already guarded by the RE that should not accept
+                    # not-int values.
                     if not only_int_re.search(str(step)):
                         raise CroniterBadCronError(
-                            f"[{expr_format}] step '{step}' in field {field_index} is not acceptable"
+                            f"[{expr_format}] step '{step}'"
+                            f" in field {field_index} is not acceptable"
                         )
                     step = int(step)
 
                     for band in low, high:
                         if not only_int_re.search(str(band)):
                             raise CroniterBadCronError(
-                                f"[{expr_format}] bands '{low}-{high}' in field {field_index} are not acceptable"
+                                f"[{expr_format}] bands '{low}-{high}'"
+                                f" in field {field_index} are not acceptable"
                             )
 
-                    low, high = (cls.value_alias(int(_val), field_index, expressions) for _val in (low, high))
+                    low, high = (
+                        cls.value_alias(int(_val), field_index, expressions)
+                        for _val in (low, high)
+                    )
 
-                    if max(low, high) > max(cls.RANGES[field_index][0], cls.RANGES[field_index][1]):
+                    if max(low, high) > max(
+                        cls.RANGES[field_index][0], cls.RANGES[field_index][1]
+                    ):
                         raise CroniterBadCronError(f"{expr_format} is out of bands")
 
                     if from_timestamp:
-                        low = cls._get_low_from_current_date_number(field_index, int(step), int(from_timestamp))
+                        low = cls._get_low_from_current_date_number(
+                            field_index, int(step), int(from_timestamp)
+                        )
 
                     # Handle when the second bound of the range is in backtracking order:
                     # eg: X-Sun or X-7 (Sat-Sun) in DOW, or X-Jan (Apr-Jan) in MONTH
                     if low > high:
                         whole_field_range = list(
-                            range(
-                                cls.RANGES[field_index][0],
-                                cls.RANGES[field_index][1] + 1,
-                                1,
-                            )
+                            range(cls.RANGES[field_index][0], cls.RANGES[field_index][1] + 1, 1)
                         )
                         # Add FirstBound -> ENDRANGE, respecting step
                         rng = list(range(low, cls.RANGES[field_index][1] + 1, step))
@@ -955,18 +923,16 @@ class croniter:
                         if rng:
                             already_skipped = list(reversed(whole_field_range)).index(rng[-1])
                             curpos = whole_field_range.index(rng[-1])
-                            if ((curpos + step) > len(whole_field_range)) and (already_skipped < step):
+                            if ((curpos + step) > len(whole_field_range)) and (
+                                already_skipped < step
+                            ):
                                 to_skip = step - already_skipped
                         rng += list(range(cls.RANGES[field_index][0] + to_skip, high + 1, step))
                     # if we include a range type: Jan-Jan, or Sun-Sun,
                     #  it means the whole cycle (all days of week, # all monthes of year, etc)
                     elif low == high:
                         rng = list(
-                            range(
-                                cls.RANGES[field_index][0],
-                                cls.RANGES[field_index][1] + 1,
-                                step,
-                            )
+                            range(cls.RANGES[field_index][0], cls.RANGES[field_index][1] + 1, step)
                         )
                     else:
                         try:
@@ -979,7 +945,9 @@ class croniter:
                     e_list += [a for a in rng if a not in e_list]
                 else:
                     if t.startswith("-"):
-                        raise CroniterBadCronError(f"[{expr_format}] is not acceptable, negative numbers not allowed")
+                        raise CroniterBadCronError(
+                            f"[{expr_format}] is not acceptable, negative numbers not allowed"
+                        )
                     if not star_or_int_re.search(t):
                         t = cls._alphaconv(field_index, t, expressions)
 
@@ -993,7 +961,9 @@ class croniter:
                     if t not in ["*", "l"] and (
                         int(t) < cls.RANGES[field_index][0] or int(t) > cls.RANGES[field_index][1]
                     ):
-                        raise CroniterBadCronError(f"[{expr_format}] is not acceptable, out of range")
+                        raise CroniterBadCronError(
+                            f"[{expr_format}] is not acceptable, out of range"
+                        )
 
                     res.append(t)
 
@@ -1023,8 +993,9 @@ class croniter:
             # Skip: if it's all weeks instead of wildcard
             if dow_expanded_set and len(set(expanded[DOW_FIELD])) != cls.LEN_MEANS_ALL[DOW_FIELD]:
                 raise CroniterUnsupportedSyntaxError(
-                    f"day-of-week field does not support mixing literal values and nth day of week syntax.  "
-                    f"Cron: '{expr_format}'    dow={dow_expanded_set} vs nth={nth_weekday_of_month}"
+                    f"day-of-week field does not support mixing literal values and nth"
+                    f" day of week syntax.  Cron: '{expr_format}'"
+                    f"    dow={dow_expanded_set} vs nth={nth_weekday_of_month}"
                 )
 
         EXPRESSIONS[(expr_format, hash_id, second_at_beginning)] = expressions
@@ -1106,13 +1077,7 @@ class croniter:
         raise ValueError("Can't get current date number for index larger than 4")
 
     @classmethod
-    def is_valid(
-        cls,
-        expression,
-        hash_id=None,
-        encoding="UTF-8",
-        second_at_beginning=False,
-    ):
+    def is_valid(cls, expression, hash_id=None, encoding="UTF-8", second_at_beginning=False):
         if hash_id:
             if not isinstance(hash_id, (bytes, str)):
                 raise TypeError("hash_id must be bytes or UTF-8 string")
@@ -1130,12 +1095,7 @@ class croniter:
 
     @classmethod
     def match_range(
-        cls,
-        cron_expression,
-        from_datetime,
-        to_datetime,
-        day_or=True,
-        second_at_beginning=False,
+        cls, cron_expression, from_datetime, to_datetime, day_or=True, second_at_beginning=False
     ):
         cron = cls(
             cron_expression,
@@ -1179,10 +1139,16 @@ def croniter_range(
     _croniter = _croniter or croniter
     auto_rt = datetime.datetime
     # type is used in first if branch for perfs reasons
-    if type(start) is not type(stop) and not (isinstance(start, type(stop)) or isinstance(stop, type(start))):
-        raise CroniterBadTypeRangeError(f"The start and stop must be same type.  {type(start)} != {type(stop)}")
+    if type(start) is not type(stop) and not (
+        isinstance(start, type(stop)) or isinstance(stop, type(start))
+    ):
+        raise CroniterBadTypeRangeError(
+            f"The start and stop must be same type.  {type(start)} != {type(stop)}"
+        )
     if isinstance(start, (float, int)):
-        start, stop = (datetime.datetime.fromtimestamp(t, tzutc()).replace(tzinfo=None) for t in (start, stop))
+        start, stop = (
+            datetime.datetime.fromtimestamp(t, tzutc()).replace(tzinfo=None) for t in (start, stop)
+        )
         auto_rt = float
     if ret_type is None:
         ret_type = auto_rt
@@ -1303,13 +1269,7 @@ class HashExpander:
             return f"{x}-{self.cron.RANGES[idx][1]}/{int(m['divisor'])}"
 
         # Example: H -> 32
-        return str(
-            self.do(
-                idx,
-                hash_type=m["hash_type"],
-                hash_id=hash_id,
-            )
-        )
+        return str(self.do(idx, hash_type=m["hash_type"], hash_id=hash_id))
 
 
 EXPANDERS = {"hash": HashExpander}

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -487,7 +487,10 @@ class croniter:
             offset = relativedelta(microseconds=-1)
         else:
             nearest_diff_method = self._get_next_nearest_diff
-            offset = relativedelta(seconds=1) if len(expanded) > UNIX_CRON_LEN else relativedelta(minutes=1)
+            if len(expanded) > UNIX_CRON_LEN:
+                offset = relativedelta(seconds=1)
+            else:
+                offset = relativedelta(minutes=1)
         dst = now + offset
         if len(expanded) > UNIX_CRON_LEN:
             dst = dst.replace(microsecond=0)
@@ -971,7 +974,8 @@ class croniter:
                         except ValueError as exc:
                             raise CroniterBadCronError(f"invalid range: {exc}")
 
-                    rng = [f"{item}#{nth}" for item in rng] if field_index == DOW_FIELD and nth and nth != "l" else rng
+                    if field_index == DOW_FIELD and nth and nth != "l":
+                        rng = [f"{item}#{nth}" for item in rng]
                     e_list += [a for a in rng if a not in e_list]
                 else:
                     if t.startswith("-"):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -229,10 +229,7 @@ class CroniterTest(base.TestCase):
 
         # INTERSECTION OF "every odd-numbered day" and "every Saturday"
         itr = croniter(
-            expr,
-            start_time=datetime(2023, 5, 2),
-            ret_type=datetime,
-            implement_cron_bug=True,
+            expr, start_time=datetime(2023, 5, 2), ret_type=datetime, implement_cron_bug=True
         )
         self.assertEqual(itr.get_next(), datetime(2023, 5, 13, 16, 0, 0))  # Sat May  13 2023
         self.assertEqual(itr.get_next(), datetime(2023, 5, 27, 16, 0, 0))  # Sat May  27 2023
@@ -379,7 +376,9 @@ class CroniterTest(base.TestCase):
         self.assertEqual(croniter("* * * * * 1,5,*/20,20,15").expanded[s], [0, 1, 5, 15, 20, 40])
         self.assertEqual(croniter("* 4,1-4,5,4 * * *").expanded[h], [1, 2, 3, 4, 5])
         # Real life example
-        self.assertEqual(croniter("59 23 * 1 wed,fri,mon-thu,tue,tue").expanded[dow], [1, 2, 3, 4, 5])
+        self.assertEqual(
+            croniter("59 23 * 1 wed,fri,mon-thu,tue,tue").expanded[dow], [1, 2, 3, 4, 5]
+        )
 
     def test_prev_minute(self):
         base = datetime(2010, 8, 25, 15, 56)
@@ -885,9 +884,7 @@ class CroniterTest(base.TestCase):
     def test_error_bad_cron(self):
         self.assertRaises(CroniterBadCronError, croniter.expand, "* * * *")
         self.assertRaises(
-            CroniterBadCronError,
-            croniter.expand,
-            ("* " * (max(VALID_LEN_EXPRESSION) + 1)).strip(),
+            CroniterBadCronError, croniter.expand, ("* " * (max(VALID_LEN_EXPRESSION) + 1)).strip()
         )
 
     def test_is_valid(self):
@@ -926,34 +923,16 @@ class CroniterTest(base.TestCase):
         _croniter = partial(croniter, "0 10 * * *", ret_type=datetime)
 
         dt = datetime(2018, 1, 2, 10, 0, 0, 500)
-        self.assertEqual(
-            _croniter(start_time=dt).get_prev(),
-            datetime(2018, 1, 2, 10, 0),
-        )
-        self.assertEqual(
-            _croniter(start_time=dt).get_next(),
-            datetime(2018, 1, 3, 10, 0),
-        )
+        self.assertEqual(_croniter(start_time=dt).get_prev(), datetime(2018, 1, 2, 10, 0))
+        self.assertEqual(_croniter(start_time=dt).get_next(), datetime(2018, 1, 3, 10, 0))
 
         dt = datetime(2018, 1, 2, 10, 0, 1, 0)
-        self.assertEqual(
-            _croniter(start_time=dt).get_prev(),
-            datetime(2018, 1, 2, 10, 0),
-        )
-        self.assertEqual(
-            _croniter(start_time=dt).get_next(),
-            datetime(2018, 1, 3, 10, 0),
-        )
+        self.assertEqual(_croniter(start_time=dt).get_prev(), datetime(2018, 1, 2, 10, 0))
+        self.assertEqual(_croniter(start_time=dt).get_next(), datetime(2018, 1, 3, 10, 0))
 
         dt = datetime(2018, 1, 2, 9, 59, 59, 999999)
-        self.assertEqual(
-            _croniter(start_time=dt).get_prev(),
-            datetime(2018, 1, 1, 10, 0),
-        )
-        self.assertEqual(
-            _croniter(start_time=dt).get_next(),
-            datetime(2018, 1, 2, 10, 0),
-        )
+        self.assertEqual(_croniter(start_time=dt).get_prev(), datetime(2018, 1, 1, 10, 0))
+        self.assertEqual(_croniter(start_time=dt).get_next(), datetime(2018, 1, 2, 10, 0))
 
     def test_invalid_zerorepeat(self):
         self.assertFalse(croniter.is_valid("*/0 * * * *"))
@@ -1046,57 +1025,54 @@ class CroniterTest(base.TestCase):
         self.assertTrue(croniter.match("0 0 * * * 1", datetime(2023, 5, 25, 0, 0, 1, 0)))
         self.assertFalse(croniter.match("0 0 * * * 1", datetime(2023, 5, 25, 0, 0, 2, 0)))
         self.assertTrue(croniter.match("31 * * * *", datetime(2019, 1, 14, 1, 31, 0, 0)))
-        self.assertTrue(croniter.match("0 0 10 * wed", datetime(2020, 6, 10, 0, 0, 0, 0), day_or=True))
-        self.assertTrue(croniter.match("0 0 10 * fri", datetime(2020, 6, 10, 0, 0, 0, 0), day_or=True))
-        self.assertTrue(croniter.match("0 0 10 * fri", datetime(2020, 6, 12, 0, 0, 0, 0), day_or=True))
-        self.assertTrue(croniter.match("0 0 10 * wed", datetime(2020, 6, 10, 0, 0, 0, 0), day_or=False))
-        self.assertFalse(croniter.match("0 0 10 * fri", datetime(2020, 6, 10, 0, 0, 0, 0), day_or=False))
-        self.assertFalse(croniter.match("0 0 10 * fri", datetime(2020, 6, 12, 0, 0, 0, 0), day_or=False))
+        self.assertTrue(
+            croniter.match("0 0 10 * wed", datetime(2020, 6, 10, 0, 0, 0, 0), day_or=True)
+        )
+        self.assertTrue(
+            croniter.match("0 0 10 * fri", datetime(2020, 6, 10, 0, 0, 0, 0), day_or=True)
+        )
+        self.assertTrue(
+            croniter.match("0 0 10 * fri", datetime(2020, 6, 12, 0, 0, 0, 0), day_or=True)
+        )
+        self.assertTrue(
+            croniter.match("0 0 10 * wed", datetime(2020, 6, 10, 0, 0, 0, 0), day_or=False)
+        )
+        self.assertFalse(
+            croniter.match("0 0 10 * fri", datetime(2020, 6, 10, 0, 0, 0, 0), day_or=False)
+        )
+        self.assertFalse(
+            croniter.match("0 0 10 * fri", datetime(2020, 6, 12, 0, 0, 0, 0), day_or=False)
+        )
 
     def test_match_handle_bad_cron(self):
         # some cron expression can"t get prev value and should not raise exception
         self.assertFalse(croniter.match("0 0 31 1 1#1", datetime(2020, 1, 31), day_or=False))
-        self.assertFalse(
-            croniter.match(
-                "0 0 31 1 * 0 2024/2",
-                datetime(2020, 1, 31),
-            )
-        )
+        self.assertFalse(croniter.match("0 0 31 1 * 0 2024/2", datetime(2020, 1, 31)))
 
     def test_match_range(self):
         self.assertTrue(
             croniter.match_range(
-                "0 0 * * *",
-                datetime(2019, 1, 13, 0, 59, 0, 0),
-                datetime(2019, 1, 14, 0, 1, 0, 0),
+                "0 0 * * *", datetime(2019, 1, 13, 0, 59, 0, 0), datetime(2019, 1, 14, 0, 1, 0, 0)
             )
         )
         self.assertFalse(
             croniter.match_range(
-                "0 0 * * *",
-                datetime(2019, 1, 13, 0, 1, 0, 0),
-                datetime(2019, 1, 13, 0, 59, 0, 0),
+                "0 0 * * *", datetime(2019, 1, 13, 0, 1, 0, 0), datetime(2019, 1, 13, 0, 59, 0, 0)
             )
         )
         self.assertTrue(
             croniter.match_range(
-                "0 0 * * * 1",
-                datetime(2023, 5, 25, 0, 0, 0, 0),
-                datetime(2023, 5, 25, 0, 0, 2, 0),
+                "0 0 * * * 1", datetime(2023, 5, 25, 0, 0, 0, 0), datetime(2023, 5, 25, 0, 0, 2, 0)
             )
         )
         self.assertFalse(
             croniter.match_range(
-                "0 0 * * * 1",
-                datetime(2023, 5, 25, 0, 0, 2, 0),
-                datetime(2023, 5, 25, 0, 0, 4, 0),
+                "0 0 * * * 1", datetime(2023, 5, 25, 0, 0, 2, 0), datetime(2023, 5, 25, 0, 0, 4, 0)
             )
         )
         self.assertTrue(
             croniter.match_range(
-                "0 0 * * * 1",
-                datetime(2023, 5, 25, 0, 0, 1, 0),
-                datetime(2023, 5, 25, 0, 0, 4, 0),
+                "0 0 * * * 1", datetime(2023, 5, 25, 0, 0, 1, 0), datetime(2023, 5, 25, 0, 0, 4, 0)
             )
         )
         self.assertTrue(
@@ -1449,16 +1425,8 @@ class CroniterTest(base.TestCase):
         cron_a = "0 0 * * 6#1"
         cron_b = "0 0 * * L6"
         cron_c = "0 0 * * L6,6#1"
-        expect_a = [
-            datetime(2021, 3, 6),
-            datetime(2021, 4, 3),
-            datetime(2021, 5, 1),
-        ]
-        expect_b = [
-            datetime(2021, 3, 27),
-            datetime(2021, 4, 24),
-            datetime(2021, 5, 29),
-        ]
+        expect_a = [datetime(2021, 3, 6), datetime(2021, 4, 3), datetime(2021, 5, 1)]
+        expect_b = [datetime(2021, 3, 27), datetime(2021, 4, 24), datetime(2021, 5, 29)]
         expect_c = sorted(expect_a + expect_b)
 
         def getn(expr, n):
@@ -1475,16 +1443,8 @@ class CroniterTest(base.TestCase):
         cron_a = "0 0 * * 1#4"
         cron_b = "0 0 * * L1"
         cron_c = "0 0 * * 1#4,L1"
-        expect_a = [
-            datetime(2021, 11, 22),
-            datetime(2021, 12, 27),
-            datetime(2022, 1, 24),
-        ]
-        expect_b = [
-            datetime(2021, 11, 29),
-            datetime(2021, 12, 27),
-            datetime(2022, 1, 31),
-        ]
+        expect_a = [datetime(2021, 11, 22), datetime(2021, 12, 27), datetime(2022, 1, 24)]
+        expect_b = [datetime(2021, 11, 29), datetime(2021, 12, 27), datetime(2022, 1, 31)]
         expect_c = sorted(set(expect_a) | set(expect_b))
 
         def getn(expr, n):
@@ -1667,10 +1627,7 @@ class CroniterTest(base.TestCase):
         ret = []
         for i in range(1, 31):
             ret.append(
-                (
-                    i,
-                    croniter("35 * 1-l/8 * *", datetime(2020, 1, i), ret_type=datetime).get_next(),
-                )
+                (i, croniter("35 * 1-l/8 * *", datetime(2020, 1, i), ret_type=datetime).get_next())
             )
             i += 1
         self.assertEqual(
@@ -1716,7 +1673,8 @@ class CroniterTest(base.TestCase):
         with self.assertRaises(CroniterBadDateError):
             it = croniter(cron, start, day_or=False, max_years_between_matches=1)
             it.get_next()
-        # New functionality (0.3.35) allowing croniter to find spare matches of cron patterns across multiple years
+        # New functionality (0.3.35) allowing croniter to find spare matches of cron
+        # patterns across multiple years
         it = croniter(cron, start, day_or=False, max_years_between_matches=5)
         self.assertEqual(it.get_next(datetime), datetime(2025, 1, 8, 13))
 
@@ -1732,13 +1690,17 @@ class CroniterTest(base.TestCase):
         with self.assertRaises(CroniterBadDateError):
             next(iterable)
 
-        iterable = croniter(cron, start, day_or=False, max_years_between_matches=5).all_next(datetime)
+        iterable = croniter(cron, start, day_or=False, max_years_between_matches=5).all_next(
+            datetime
+        )
         n = next(iterable)
         self.assertEqual(n, datetime(2025, 1, 8, 13))
 
         # If the explicitly given lookahead isn't enough to reach the next date, that's fine.
         # The caller specified the maximum gap, so no just stop iteration
-        iterable = croniter(cron, start, day_or=False, max_years_between_matches=2).all_next(datetime)
+        iterable = croniter(cron, start, day_or=False, max_years_between_matches=2).all_next(
+            datetime
+        )
         with self.assertRaises(StopIteration):
             next(iterable)
 
@@ -2012,10 +1974,7 @@ class CroniterTest(base.TestCase):
     def test_get_next_fails_with_expand_from_start_time_true(self):
         expanded_croniter = croniter("0 0 */5 * *", expand_from_start_time=True)
         self.assertRaises(
-            ValueError,
-            expanded_croniter.get_next,
-            datetime,
-            start_time=datetime(2024, 7, 12),
+            ValueError, expanded_croniter.get_next, datetime, start_time=datetime(2024, 7, 12)
         )
 
     def test_get_next_update_current(self):
@@ -2075,7 +2034,10 @@ class CroniterTest(base.TestCase):
         self.assertEqual(retn, retans)
 
         cron.set_current(datetime(2024, 7, 12), force=True)
-        uretn = [(cron.get_next(datetime, update_current=False), cron.get_current(datetime)) for a in range(3)]
+        uretn = [
+            (cron.get_next(datetime, update_current=False), cron.get_current(datetime))
+            for a in range(3)
+        ]
         self.assertEqual(
             uretn,
             [
@@ -2086,7 +2048,10 @@ class CroniterTest(base.TestCase):
         )
 
         cron.set_current(datetime(2024, 7, 12), force=True)
-        uretp = [(cron.get_prev(datetime, update_current=False), cron.get_current(datetime)) for a in range(3)]
+        uretp = [
+            (cron.get_prev(datetime, update_current=False), cron.get_current(datetime))
+            for a in range(3)
+        ]
         self.assertEqual(
             uretp,
             [
@@ -2336,7 +2301,9 @@ class CroniterTest(base.TestCase):
             # fmt: on
         )
 
-    def _test_cron_ranges(self, expr, wanted, generator=None, loops=None, start=None, is_prev=None):
+    def _test_cron_ranges(
+        self, expr, wanted, generator=None, loops=None, start=None, is_prev=None
+    ):
         rets = (generator or gen_x_results)(
             expr, loops=loops or 10, start=start or datetime(2024, 1, 1), is_prev=is_prev
         )

--- a/src/croniter/tests/test_croniter_hash.py
+++ b/src/croniter/tests/test_croniter_hash.py
@@ -11,7 +11,9 @@ class CroniterHashBase(base.TestCase):
     epoch = datetime(2020, 1, 1, 0, 0)
     hash_id = "hello"
 
-    def _test_iter(self, definition, expectations, delta, epoch=None, hash_id=None, next_type=None):
+    def _test_iter(
+        self, definition, expectations, delta, epoch=None, hash_id=None, next_type=None
+    ):
         if epoch is None:
             epoch = self.epoch
         if hash_id is None:
@@ -73,10 +75,7 @@ class CroniterHashTest(CroniterHashBase):
         """Test a different hash_id returns different results given same definition and epoch"""
         self._test_iter("H H * * *", datetime(2020, 1, 1, 11, 10), timedelta(days=1))
         self._test_iter(
-            "H H * * *",
-            datetime(2020, 1, 1, 0, 24),
-            timedelta(days=1),
-            hash_id="different id",
+            "H H * * *", datetime(2020, 1, 1, 0, 24), timedelta(days=1), hash_id="different id"
         )
 
     def test_hash_epoch_change(self):
@@ -92,12 +91,16 @@ class CroniterHashTest(CroniterHashBase):
     def test_hash_range(self):
         """Test a hashed range definition"""
         self._test_iter("H H H(3-5) * *", datetime(2020, 1, 5, 11, 10), timedelta(days=31))
-        self._test_iter("H H * * * 0 H(2025-2030)", datetime(2029, 1, 1, 11, 10), timedelta(days=1))
+        self._test_iter(
+            "H H * * * 0 H(2025-2030)", datetime(2029, 1, 1, 11, 10), timedelta(days=1)
+        )
 
     def test_hash_division(self):
         """Test a hashed division definition"""
         self._test_iter("H H/3 * * *", datetime(2020, 1, 1, 2, 10), timedelta(hours=3))
-        self._test_iter("H H H H * H H/2", datetime(2020, 9, 1, 11, 10, 32), timedelta(days=365 * 2))
+        self._test_iter(
+            "H H H H * H H/2", datetime(2020, 9, 1, 11, 10, 32), timedelta(days=365 * 2)
+        )
 
     def test_hash_range_division(self):
         """Test a hashed range + division definition"""
@@ -106,7 +109,9 @@ class CroniterHashTest(CroniterHashBase):
     def test_hash_invalid_range(self):
         """Test validation logic for range_begin and range_end values"""
         try:
-            self._test_iter("H(11-10) H * * *", datetime(2020, 1, 1, 11, 31), timedelta(minutes=10))
+            self._test_iter(
+                "H(11-10) H * * *", datetime(2020, 1, 1, 11, 31), timedelta(minutes=10)
+            )
         except CroniterBadCronError as ex:
             self.assertEqual(str(ex), "Range end must be greater than range begin")
 

--- a/src/croniter/tests/test_croniter_range.py
+++ b/src/croniter/tests/test_croniter_range.py
@@ -5,7 +5,13 @@ from datetime import datetime
 
 import pytz
 
-from croniter import CroniterBadCronError, CroniterBadDateError, CroniterBadTypeRangeError, croniter, croniter_range
+from croniter import (
+    CroniterBadCronError,
+    CroniterBadDateError,
+    CroniterBadTypeRangeError,
+    croniter,
+    croniter_range,
+)
 from croniter.tests import base
 
 
@@ -118,20 +124,25 @@ class CroniterRangeTest(base.TestCase):
         with self.assertRaises(CroniterBadDateError):
             it = croniter(cron, start, day_or=False, max_years_between_matches=1)
             it.get_next()
-        # New functionality (0.3.35) allowing croniter to find spare matches of cron patterns across multiple years
+        # New functionality (0.3.35) allowing croniter to find spare matches of cron
+        # patterns across multiple years
         it = croniter(cron, start, day_or=False, max_years_between_matches=5)
         self.assertEqual(it.get_next(datetime), datetime(2025, 1, 8, 13))
 
     def test_issue145_range(self):
         cron = "0 13 8 1,4,7,10 wed"
-        matches = list(croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, day_or=False))
+        matches = list(
+            croniter_range(datetime(2020, 1, 1), datetime(2020, 12, 31), cron, day_or=False)
+        )
         self.assertEqual(len(matches), 3)
         self.assertEqual(matches[0], datetime(2020, 1, 8, 13))
         self.assertEqual(matches[1], datetime(2020, 4, 8, 13))
         self.assertEqual(matches[2], datetime(2020, 7, 8, 13))
 
         # No matches within this range; therefore expect empty list
-        matches = list(croniter_range(datetime(2020, 9, 30), datetime(2020, 10, 30), cron, day_or=False))
+        matches = list(
+            croniter_range(datetime(2020, 9, 30), datetime(2020, 10, 30), cron, day_or=False)
+        )
         self.assertEqual(len(matches), 0)
 
     def test_croniter_range_derived_class(self):
@@ -166,10 +177,7 @@ class CroniterRangeTest(base.TestCase):
         with self.assertRaises(CroniterBadCronError):
             # Should similarly fail because the custom class rejects seconds expr
             i = croniter_range(
-                datetime(2020, 1, 1),
-                datetime(2020, 12, 31),
-                cron,
-                _croniter=croniter_nosec,
+                datetime(2020, 1, 1), datetime(2020, 12, 31), cron, _croniter=croniter_nosec
             )
             next(i)
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,5 +24,5 @@ commands = mypy .
 deps = -r{toxinidir}/requirements/format.txt
 changedir = src
 commands = 
-    black --check .
+    black -C --check .
     isort -c --quiet .


### PR DESCRIPTION
A line length of 119 is too wide IMO. My sweet spot line length is between 88 and 99.

Reduce line length to 99 and format the Python code with `black -C`.