### PR TITLE
Fix skipping first of March

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -690,10 +690,13 @@ class croniter:
         ( Currently, should only used for `year` field )
         """
         for i, d in enumerate(to_check):
-            if d == "l" and range_val is not None:
-                # if 'l' then it is the last day of month
-                # => its value of range_val
-                d = range_val
+            if range_val is not None:
+                if d == "l":
+                    # if 'l' then it is the last day of month
+                    # => its value of range_val
+                    d = range_val
+                elif d > range_val:
+                    continue
             if d >= x:
                 return d - x
         # When range_val is None and x not exists in to_check,

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -720,6 +720,14 @@ class CroniterTest(base.TestCase):
         self.assertEqual(base.hour, res.hour)
         self.assertEqual(base.minute, res.minute)
 
+    def test_first_of_march(self):
+        """Test not skipping first of March.
+
+        This fixes https://github.com/pallets-eco/croniter/issues/1
+        """
+        it = croniter("0 0 */10 * *", datetime(2025, 2, 22))
+        self.assertEqual(it.get_next(datetime).isoformat(), "2025-03-01T00:00:00")
+
     def test_timezone(self):
         base = datetime(2013, 3, 4, 12, 15)
         itr = croniter("* * * * *", base)


### PR DESCRIPTION
In case the month cron rule is `*/x` the first of March might be skipped. In case of `*/10` the expanded field for the day is [1, 11, 21, 31]. Despite February has at most 29 days, `proc_day_of_month` will pick 31 as next day. Adding so many days to reach the 31 of February will overshoot the first of March.

So check if the provided values are still inside the range value.

Fixes: https://github.com/pallets-eco/croniter/issues/1