### PR TITLE
Fix memory leak by removing `TIMESTAMP_TO_DT_CACHE`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 6.0.1 (unreleased)
 ------------------
 
+- Fix memory leak by removing `TIMESTAMP_TO_DT_CACHE`.
 - Announce back that croniter is maintained now as part of pallets-eco.
 
 

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -121,7 +121,6 @@ SECOND_CRON_LEN = len(SECOND_FIELDS)
 YEAR_CRON_LEN = len(YEAR_FIELDS)
 # retrocompat
 VALID_LEN_EXPRESSION = {a for a in CRON_FIELDS if isinstance(a, int)}
-TIMESTAMP_TO_DT_CACHE: dict[tuple[float, str], datetime.datetime] = {}
 EXPRESSIONS: dict[tuple[str, Optional[bytes], bool], list[str]] = {}
 MARKER = object()
 
@@ -378,11 +377,6 @@ class croniter:
         """
         if tzinfo is MARKER:  # allow to give tzinfo=None even if self.tzinfo is set
             tzinfo = self.tzinfo
-        key = (timestamp, repr(tzinfo))
-        try:
-            return TIMESTAMP_TO_DT_CACHE[key]
-        except KeyError:
-            pass
         if OVERFLOW32B_MODE:
             # degraded mode to workaround Y2038
             # see https://github.com/python/cpython/issues/101069
@@ -391,7 +385,6 @@ class croniter:
             result = datetime.datetime.fromtimestamp(timestamp, tz=tzutc()).replace(tzinfo=None)
         if tzinfo:
             result = result.replace(tzinfo=UTC_DT).astimezone(tzinfo)
-        TIMESTAMP_TO_DT_CACHE[key] = result
         return result
 
     _timestamp_to_datetime = timestamp_to_datetime  # retrocompat


### PR DESCRIPTION
This fixes https://github.com/pallets-eco/croniter/issues/182

Historically `TIMESTAMP_TO_DT_CACHE` was introduced here in a batch of many other changes before release v6.x.x: https://github.com/pallets-eco/croniter/pull/143/commits/a7e1e19e72c46f99915f16c6c76f1700b2157941 and i don't see any issue solved so this looks more like attempt to just improve performance "in advance".

What it does not take in account I think, is that there are many valid and **supported** use cases for croniter, in general those that use "start_time" argument either in new class or in `get_next` method.

For example every while loop with periodic (say 1s) invoking croniter to check if it is time to run something based on cron expression, will eventually end up eating all memory possible. This is very popular library so i suppose there will be more use cases.

> "Premature optimization is the root of all evil."

I guess :laughing: (no offense, REALLY)
