### PR TITLE
remove obsolete noqa: E241

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -65,11 +65,11 @@ M_ALPHAS: dict[str, Union[int, str]] = {
     "jan": 1,
     "feb": 2,
     "mar": 3,
-    "apr": 4,  # noqa: E241
+    "apr": 4,
     "may": 5,
     "jun": 6,
     "jul": 7,
-    "aug": 8,  # noqa: E241
+    "aug": 8,
     "sep": 9,
     "oct": 10,
     "nov": 11,


### PR DESCRIPTION
The `noqa: E241` marker are not needed any more after wrapping the lines (with ruff).