### PR TITLE
fix mem leak by removing EXPRESSIONS global dict cache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Features and Improvements
 Bugfixes
 ~~~~~~~~
 - Fix memory leak by removing `TIMESTAMP_TO_DT_CACHE` global dict cache. [1a9d3c0, Rafał Safin (@rafsaf)]
+- Fix memory leak by removing `EXPRESSIONS` global dict cache. [1883e15, @Souls-R]
 - Fix default value of `second_at_beginning` to a boolean. [dc63ed2, Benjamin Drung (@bdrung)]
 - Fix always missing the timestamp to datetime cache. [18eb299, Benjamin Drung (@bdrung)]
 - Fix skipping first of March. [de21a9d, Benjamin Drung (@bdrung)]

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -134,7 +134,7 @@ SECOND_CRON_LEN = len(SECOND_FIELDS)
 YEAR_CRON_LEN = len(YEAR_FIELDS)
 # retrocompat
 VALID_LEN_EXPRESSION = {a for a in CRON_FIELDS if isinstance(a, int)}
-EXPRESSIONS: dict[tuple[str, Optional[bytes], bool], list[str]] = {}
+
 MARKER = object()
 
 
@@ -325,14 +325,13 @@ class croniter:
         self.cur = 0.0
         self.set_current(start_time, force=True)
 
-        self.expanded, self.nth_weekday_of_month = self.expand(
+        self.expanded, self.nth_weekday_of_month, self.expressions = self._expand(
             expr_format,
             hash_id=hash_id,
             from_timestamp=self.dst_start_time if self._expand_from_start_time else None,
             second_at_beginning=second_at_beginning,
         )
         self.fields = CRON_FIELDS[len(self.expanded)]
-        self.expressions = EXPRESSIONS[(expr_format, hash_id, second_at_beginning)]
         self._is_prev = is_prev
 
     @classmethod
@@ -1081,8 +1080,7 @@ class croniter:
                     f"    dow={dow_expanded_set} vs nth={nth_weekday_of_month}"
                 )
 
-        EXPRESSIONS[(expr_format, hash_id, second_at_beginning)] = expressions
-        return expanded, nth_weekday_of_month
+        return expanded, nth_weekday_of_month, expressions
 
     @classmethod
     def expand(
@@ -1131,12 +1129,13 @@ class croniter:
         ([[0], [0], ['*'], ['*'], ['*'], [0, 15, 30, 45]], {})
         """
         try:
-            return cls._expand(
+            expanded, nth_weekday_of_month, _expressions = cls._expand(
                 expr_format,
                 hash_id=hash_id,
                 second_at_beginning=second_at_beginning,
                 from_timestamp=from_timestamp,
             )
+            return expanded, nth_weekday_of_month
         except (ValueError,) as exc:
             if isinstance(exc, CroniterError):
                 raise


### PR DESCRIPTION
fix #195

`EXPRESSIONS` global dict has the same unbounded growth issue as `TIMESTAMP_TO_DT_CACHE`, #185 removed `TIMESTAMP_TO_DT_CACHE`, but the other module-level dict `EXPRESSIONS` has the same problem, it caches every unique expression forever.

As `_expand()` benchmark below, the cache doesn't help much:
```
Same expr x10000:
  With cache:    863.2ms (86.3us/call)
  Without cache: 880.2ms (88.0us/call)
  Speedup:       1.02x

Unique exprs x10000:
  With cache:    340.5ms (34.1us/call)
  Without cache: 336.7ms (33.7us/call)
  Speedup:       0.99x
```

The cache only skips the string splitting and value expansion in `_expand()`, which is cheap. 
`_expand()` is cheap enough that the dict lookup overhead cancels out any benefit.