### PR TITLE
Add strict validation for impossible day/month cron expressions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,44 @@ You can validate your crons using ``is_valid`` class method. (>= 0.3.18)::
     >>> croniter.is_valid('0 0 1 * *')  # True
     >>> croniter.is_valid('0 wrong_value 1 * *')  # False
 
+Strict validation
+-----------------
+
+By default, ``is_valid`` and ``expand`` only check that each field is within its own range
+(e.g. day 1-31, month 1-12). They do not cross-validate fields, so expressions like
+``0 0 31 2 *`` (February 31st) are considered valid even though they can never match a real date.
+
+Use ``strict=True`` to enable cross-field validation that rejects impossible day/month
+combinations::
+
+    >>> croniter.is_valid('0 0 31 2 *')  # True (default: syntax only)
+    >>> croniter.is_valid('0 0 31 2 *', strict=True)  # False (Feb has at most 29 days)
+    >>> croniter.is_valid('0 0 31 4 *', strict=True)  # False (Apr has 30 days)
+    >>> croniter.is_valid('0 0 30 1,2 *', strict=True)  # True (day 30 is valid in Jan)
+
+When ``strict=True`` and the expression does not include a year field, February is assumed to
+have 29 days (since leap years exist)::
+
+    >>> croniter.is_valid('0 0 29 2 *', strict=True)  # True (leap years exist)
+
+If the expression includes a year field (7-field format), leap year status is determined from
+the specified years::
+
+    >>> croniter.is_valid('0 0 29 2 * 0 2024', strict=True)  # True (2024 is a leap year)
+    >>> croniter.is_valid('0 0 29 2 * 0 2023', strict=True)  # False (2023 is not)
+    >>> croniter.is_valid('0 0 29 2 * 0 2023-2025', strict=True)  # True (2024 in range is a leap year)
+
+For 5- or 6-field expressions, you can pass ``strict_year`` to provide the year(s) for
+leap year checking without adding a year field to the expression::
+
+    >>> croniter.is_valid('0 0 29 2 *', strict=True, strict_year=2024)  # True (leap year)
+    >>> croniter.is_valid('0 0 29 2 *', strict=True, strict_year=2023)  # False (not a leap year)
+    >>> croniter.is_valid('0 0 29 2 *', strict=True, strict_year=[2023, 2024])  # True (2024 is a leap year)
+
+The ``strict`` and ``strict_year`` parameters are also available on ``expand()``::
+
+    >>> croniter.expand('0 0 31 2 *', strict=True)  # raises CroniterBadCronError
+
 About DST
 =========
 Be sure to init your croniter instance with a TZ aware datetime for this to work!

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -849,8 +849,11 @@ class croniter:
             val = cls.LOWMAP[field_index][val]
         return val
 
+    # Maximum days in each month (non-leap year for Feb)
+    DAYS_IN_MONTH = {1: 31, 2: 28, 3: 31, 4: 30, 5: 31, 6: 30, 7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31}
+
     @classmethod
-    def _expand(cls, expr_format, hash_id=None, second_at_beginning=False, from_timestamp=None):
+    def _expand(cls, expr_format, hash_id=None, second_at_beginning=False, from_timestamp=None, strict=False, strict_year=None):
         # Split the expression in components, and normalize L -> l, MON -> mon,
         # etc. Keep expr_format untouched so we can use it in the exception
         # messages.
@@ -1080,6 +1083,41 @@ class croniter:
                     f"    dow={dow_expanded_set} vs nth={nth_weekday_of_month}"
                 )
 
+        if strict:
+            # Cross-validate day-of-month against month (and optionally year)
+            # to reject impossible combinations like "0 0 31 2 *" (Feb 31st).
+            days = expanded[DAY_FIELD]
+            months = expanded[MONTH_FIELD]
+            if days != ["*"] and days != ["l"] and months != ["*"]:
+                int_days = [d for d in days if isinstance(d, int)]
+                int_months = [m for m in months if isinstance(m, int)]
+                if int_days and int_months:
+                    # Determine max days per month, accounting for leap years
+                    days_in_month = dict(cls.DAYS_IN_MONTH)
+                    if 2 in int_months:
+                        has_leap_year = True  # assume possible by default
+                        if strict_year is not None:
+                            # Year explicitly provided as parameter
+                            if isinstance(strict_year, int):
+                                has_leap_year = calendar.isleap(strict_year)
+                            else:
+                                has_leap_year = any(calendar.isleap(y) for y in strict_year)
+                        elif len(expanded) > YEAR_FIELD:
+                            years = expanded[YEAR_FIELD]
+                            if years != ["*"]:
+                                int_years = [y for y in years if isinstance(y, int)]
+                                if int_years:
+                                    has_leap_year = any(calendar.isleap(y) for y in int_years)
+                        if has_leap_year:
+                            days_in_month[2] = 29
+                    min_day = min(int_days)
+                    max_possible = max(days_in_month[m] for m in int_months)
+                    if min_day > max_possible:
+                        raise CroniterBadCronError(
+                            f"[{expr_format}] is not acceptable. Day(s) {int_days}"
+                            f" can never occur in month(s) {int_months}"
+                        )
+
         return expanded, nth_weekday_of_month, expressions
 
     @classmethod
@@ -1089,6 +1127,8 @@ class croniter:
         hash_id: Optional[Union[bytes, str]] = None,
         second_at_beginning: bool = False,
         from_timestamp: Optional[float] = None,
+        strict: bool = False,
+        strict_year: Optional[Union[int, list[int]]] = None,
     ) -> tuple[list[ExpandedExpression], dict[int, set[int]]]:
         """
         Expand a cron expression format into a noramlized format of
@@ -1134,6 +1174,8 @@ class croniter:
                 hash_id=hash_id,
                 second_at_beginning=second_at_beginning,
                 from_timestamp=from_timestamp,
+                strict=strict,
+                strict_year=strict_year,
             )
             return expanded, nth_weekday_of_month
         except (ValueError,) as exc:
@@ -1159,14 +1201,14 @@ class croniter:
         raise ValueError("Can't get current date number for index larger than 4")
 
     @classmethod
-    def is_valid(cls, expression, hash_id=None, encoding="UTF-8", second_at_beginning=False):
+    def is_valid(cls, expression, hash_id=None, encoding="UTF-8", second_at_beginning=False, strict=False, strict_year=None):
         if hash_id:
             if not isinstance(hash_id, (bytes, str)):
                 raise TypeError("hash_id must be bytes or UTF-8 string")
             if not isinstance(hash_id, bytes):
                 hash_id = hash_id.encode(encoding)
         try:
-            cls.expand(expression, hash_id=hash_id, second_at_beginning=second_at_beginning)
+            cls.expand(expression, hash_id=hash_id, second_at_beginning=second_at_beginning, strict=strict, strict_year=strict_year)
         except CroniterError:
             return False
         return True

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1077,6 +1077,75 @@ class CroniterTest(base.TestCase):
         self.assertFalse(croniter.is_valid("* * * janu-jun *"))
         self.assertTrue(croniter.is_valid("H 0 * * *", hash_id="abc"))
 
+    def test_is_valid_strict(self):
+        # Feb 31 - never exists
+        self.assertTrue(croniter.is_valid("0 0 31 2 *"))
+        self.assertFalse(croniter.is_valid("0 0 31 2 *", strict=True))
+        # Feb 30 - never exists
+        self.assertFalse(croniter.is_valid("0 0 30 2 *", strict=True))
+        # Apr 31 - never exists
+        self.assertFalse(croniter.is_valid("0 0 31 4 *", strict=True))
+        # Jun 31 - never exists
+        self.assertFalse(croniter.is_valid("0 0 31 6 *", strict=True))
+        # Feb 29 without year - valid (leap years exist)
+        self.assertTrue(croniter.is_valid("0 0 29 2 *", strict=True))
+        # Jan 31 - valid
+        self.assertTrue(croniter.is_valid("0 0 31 1 *", strict=True))
+        # Day 31 in months 1,2 - day 31 is reachable in Jan
+        self.assertTrue(croniter.is_valid("0 0 31 1,2 *", strict=True))
+        # Day 30 in months 2,4 - day 30 is reachable in Apr
+        self.assertTrue(croniter.is_valid("0 0 30 2,4 *", strict=True))
+        # Wildcard month - always valid
+        self.assertTrue(croniter.is_valid("0 0 31 * *", strict=True))
+        # Wildcard day - always valid
+        self.assertTrue(croniter.is_valid("0 0 * 2 *", strict=True))
+        # Last day of month - always valid
+        self.assertTrue(croniter.is_valid("0 0 l * *", strict=True))
+        # Normal expressions remain valid
+        self.assertTrue(croniter.is_valid("0 * * * *", strict=True))
+        self.assertTrue(croniter.is_valid("*/5 * * * *", strict=True))
+        # expand() also supports strict
+        with self.assertRaises(CroniterBadCronError):
+            croniter.expand("0 0 31 2 *", strict=True)
+
+    def test_is_valid_strict_with_year(self):
+        # Feb 29 in a leap year - valid
+        self.assertTrue(croniter.is_valid("0 0 29 2 * 0 2024", strict=True))
+        self.assertTrue(croniter.is_valid("0 0 29 2 * 0 2028", strict=True))
+        # Feb 29 in a non-leap year - invalid
+        self.assertFalse(croniter.is_valid("0 0 29 2 * 0 2023", strict=True))
+        self.assertFalse(croniter.is_valid("0 0 29 2 * 0 2025", strict=True))
+        # Feb 29 with mixed years (some leap, some not) - valid
+        self.assertTrue(croniter.is_valid("0 0 29 2 * 0 2023,2024", strict=True))
+        # Feb 29 with year range including a leap year - valid
+        self.assertTrue(croniter.is_valid("0 0 29 2 * 0 2023-2025", strict=True))
+        # Feb 29 with year range of all non-leap years - invalid
+        self.assertFalse(croniter.is_valid("0 0 29 2 * 0 2025-2027", strict=True))
+        # Feb 31 with any year - always invalid
+        self.assertFalse(croniter.is_valid("0 0 31 2 * 0 2024", strict=True))
+        # Feb 30 with leap year - still invalid (leap year only adds day 29)
+        self.assertFalse(croniter.is_valid("0 0 30 2 * 0 2024", strict=True))
+        # Wildcard year - Feb 29 valid (leap years exist)
+        self.assertTrue(croniter.is_valid("0 0 29 2 * 0 *", strict=True))
+
+    def test_is_valid_strict_year_parameter(self):
+        # 5-field expression with strict_year parameter
+        # Feb 29 with leap year param - valid
+        self.assertTrue(croniter.is_valid("0 0 29 2 *", strict=True, strict_year=2024))
+        self.assertTrue(croniter.is_valid("0 0 29 2 *", strict=True, strict_year=2000))
+        # Feb 29 with non-leap year param - invalid
+        self.assertFalse(croniter.is_valid("0 0 29 2 *", strict=True, strict_year=2023))
+        self.assertFalse(croniter.is_valid("0 0 29 2 *", strict=True, strict_year=1900))
+        # Feb 31 - invalid regardless of year
+        self.assertFalse(croniter.is_valid("0 0 31 2 *", strict=True, strict_year=2024))
+        # strict_year as list of years
+        self.assertTrue(croniter.is_valid("0 0 29 2 *", strict=True, strict_year=[2023, 2024]))
+        self.assertFalse(croniter.is_valid("0 0 29 2 *", strict=True, strict_year=[2023, 2025]))
+        # Non-Feb months ignore strict_year
+        self.assertTrue(croniter.is_valid("0 0 31 1 *", strict=True, strict_year=2023))
+        # strict_year without strict has no effect (backward compatible)
+        self.assertTrue(croniter.is_valid("0 0 31 2 *", strict_year=2024))
+
     def test_exactly_the_same_minute(self):
         base = datetime(2018, 3, 5, 12, 30, 50)
         itr = croniter("30 7,12,17 * * *", base)


### PR DESCRIPTION
## Summary
- Add `strict` parameter to `is_valid()` and `expand()` that cross-validates day-of-month against month to reject impossible combinations (e.g. Feb 31, Apr 31)
- Add `strict_year` parameter to provide year(s) for leap year checking in 5/6-field expressions
- Handle leap years automatically when a year field is present in 7-field expressions
- Document the new strict validation feature in README.rst

Fixes #141

## Test plan
- [x] `test_is_valid_strict` — impossible day/month combos, wildcards, last-day, normal expressions
- [x] `test_is_valid_strict_with_year` — 7-field expressions with leap/non-leap years
- [x] `test_is_valid_strict_year_parameter` — `strict_year` as int and list, backward compatibility
- [x] Full test suite passes (124 tests)