### PR TITLE
Add support for W (nearest weekday) in day-of-month field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,34 @@ The ``strict`` and ``strict_year`` parameters are also available on ``expand()``
 
     >>> croniter.expand('0 0 31 2 *', strict=True)  # raises CroniterBadCronError
 
+Nearest weekday (W)
+===================
+
+The ``W`` character is supported in the day-of-month field to specify the nearest weekday
+(Monday-Friday) to the given day. Both ``nW`` and ``Wn`` formats are accepted::
+
+    >>> base = datetime(2024, 6, 1)
+    >>> itr = croniter('0 9 15W * *', base)
+    >>> itr.get_next(datetime)   # Jun 15 2024 is Saturday -> fires on Friday 14th
+    datetime.datetime(2024, 6, 14, 9, 0)
+
+Rules:
+
+- If the specified day falls on a weekday, the trigger fires on that day.
+- If the specified day falls on Saturday, the trigger fires on the preceding Friday.
+- If the specified day falls on Sunday, the trigger fires on the following Monday.
+- The nearest weekday never crosses month boundaries. If the 1st is a Saturday, the trigger
+  fires on Monday the 3rd. If the last day of the month is a Sunday, the trigger fires on the
+  preceding Friday.
+- ``W`` can only be used with a single day value, not in a range or list.
+
+Examples::
+
+    >>> croniter('0 9 1W * *', datetime(2024, 5, 31)).get_next(datetime)   # Jun 1 is Sat -> Mon 3rd
+    datetime.datetime(2024, 6, 3, 9, 0)
+    >>> croniter('0 9 W15 * *', datetime(2024, 1, 1)).get_next(datetime)   # Wn format also works
+    datetime.datetime(2024, 1, 15, 9, 0)
+
 About DST
 =========
 Be sure to init your croniter instance with a TZ aware datetime for this to work!

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -116,6 +116,7 @@ special_dow_re = re.compile(
     rf"^(?P<pre>((?P<he>(({WEEKDAYS})(-({WEEKDAYS}))?)"
     rf"|(({MONTHS})(-({MONTHS}))?)|\w+)#)|l)(?P<last>\d+)$"
 )
+nearest_weekday_re = re.compile(r"^(?:(\d+)w|w(\d+))$")
 re_star = re.compile("[*]")
 hash_expression_re = re.compile(
     r"^(?P<hash_type>h|r)(\((?P<range_begin>\d+)-(?P<range_end>\d+)\))?(\/(?P<divisor>\d+))?$"
@@ -325,7 +326,7 @@ class croniter:
         self.cur = 0.0
         self.set_current(start_time, force=True)
 
-        self.expanded, self.nth_weekday_of_month, self.expressions = self._expand(
+        self.expanded, self.nth_weekday_of_month, self.expressions, self.nearest_weekday = self._expand(
             expr_format,
             hash_id=hash_id,
             from_timestamp=self.dst_start_time if self._expand_from_start_time else None,
@@ -647,6 +648,32 @@ class croniter:
                 return True, d
             return False, d
 
+        def proc_nearest_weekday(d):
+            """Process W (nearest weekday) day-of-month entries."""
+            candidates = []
+            for w_day in self.nearest_weekday:
+                candidate = self._get_nearest_weekday(d.year, d.month, w_day)
+                if (is_prev and candidate <= d.day) or (not is_prev and d.day <= candidate):
+                    candidates.append(candidate)
+
+            if not candidates:
+                if is_prev:
+                    d += relativedelta(days=-d.day, hour=23, minute=59, second=59)
+                else:
+                    days = _last_day_of_month(year, month)
+                    d += relativedelta(days=(days - d.day + 1), hour=0, minute=0, second=0)
+                return True, d
+
+            candidates.sort()
+            diff_day = (candidates[-1] if is_prev else candidates[0]) - d.day
+            if diff_day != 0:
+                if is_prev:
+                    d += relativedelta(days=diff_day, hour=23, minute=59, second=59)
+                else:
+                    d += relativedelta(days=diff_day, hour=0, minute=0, second=0)
+                return True, d
+            return False, d
+
         def proc_hour(d):
             try:
                 expanded[HOUR_FIELD].index("*")
@@ -689,7 +716,7 @@ class croniter:
         procs = [
             proc_year,
             proc_month,
-            proc_day_of_month,
+            (proc_nearest_weekday if self.nearest_weekday else proc_day_of_month),
             (proc_day_of_week_nth if nth_weekday_of_month else proc_day_of_week),
             proc_hour,
             proc_minute,
@@ -831,6 +858,33 @@ class croniter:
             c.pop(0)
         return tuple(i[0] for i in c)
 
+    @staticmethod
+    def _get_nearest_weekday(year, month, day):
+        """Get the nearest weekday (Mon-Fri) to the given day in the given month.
+
+        Rules:
+        - If the day is a weekday, return it.
+        - If Saturday, return Friday (day-1), unless that crosses into previous month,
+          then return Monday (day+2).
+        - If Sunday, return Monday (day+1), unless that crosses into next month,
+          then return Friday (day-2).
+        """
+        last_day = _last_day_of_month(year, month)
+        day = min(day, last_day)
+        weekday = calendar.weekday(year, month, day)  # 0=Mon, 6=Sun
+        if weekday < 5:  # Mon-Fri
+            return day
+        if weekday == 5:  # Saturday
+            if day > 1:
+                return day - 1  # Friday
+            else:
+                return day + 2  # Monday (1st is Sat, so 3rd is Mon)
+        # Sunday
+        if day < last_day:
+            return day + 1  # Monday
+        else:
+            return day - 2  # Friday (last day is Sun, go back to Fri)
+
     @classmethod
     def value_alias(cls, val, field_index, len_expressions=UNIX_CRON_LEN):
         if isinstance(len_expressions, (list, dict, tuple, set)):
@@ -887,6 +941,7 @@ class croniter:
 
         expanded = []
         nth_weekday_of_month = {}
+        nearest_weekday = set()
 
         for field_index, expr in enumerate(expressions):
             for expanderid, expander in EXPANDERS.items():
@@ -934,6 +989,26 @@ class croniter:
                         elif last:
                             e = last
                             nth = g["pre"]  # 'l'
+
+                if field_index == DAY_FIELD:
+                    # Handle W (nearest weekday) in day-of-month: 15w, w15
+                    w_match = nearest_weekday_re.match(str(e))
+                    if w_match:
+                        w_day = int(w_match.group(1) or w_match.group(2))
+                        if w_day < 1 or w_day > 31:
+                            raise CroniterBadCronError(
+                                f"[{expr_format}] is not acceptable,"
+                                f" nearest weekday day value '{w_day}' out of range"
+                            )
+                        if len(e_list) > 0 or len(res) > 0:
+                            raise CroniterBadCronError(
+                                f"[{expr_format}] is not acceptable."
+                                f" 'W' can only be used with a single day value,"
+                                f" not in a list or range"
+                            )
+                        nearest_weekday.add(w_day)
+                        res.append(w_day)
+                        continue
 
                 # Before matching step_search_re, normalize "*" to "{min}-{max}".
                 # Example: in the minute field, "*/5" normalizes to "0-59/5"
@@ -1118,7 +1193,7 @@ class croniter:
                             f" can never occur in month(s) {int_months}"
                         )
 
-        return expanded, nth_weekday_of_month, expressions
+        return expanded, nth_weekday_of_month, expressions, nearest_weekday
 
     @classmethod
     def expand(
@@ -1169,7 +1244,7 @@ class croniter:
         ([[0], [0], ['*'], ['*'], ['*'], [0, 15, 30, 45]], {})
         """
         try:
-            expanded, nth_weekday_of_month, _expressions = cls._expand(
+            expanded, nth_weekday_of_month, _expressions, _nearest_weekday = cls._expand(
                 expr_format,
                 hash_id=hash_id,
                 second_at_beginning=second_at_beginning,

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1146,6 +1146,109 @@ class CroniterTest(base.TestCase):
         # strict_year without strict has no effect (backward compatible)
         self.assertTrue(croniter.is_valid("0 0 31 2 *", strict_year=2024))
 
+    def test_nearest_weekday_basic(self):
+        # 15W: nearest weekday to the 15th
+        # Jan 2024: 15th is Monday -> fires on 15th
+        base = datetime(2024, 1, 1)
+        itr = croniter("0 9 15W * *", base)
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 1, 15, 9, 0))
+
+        # Feb 2024: 15th is Thursday -> fires on 15th
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 2, 15, 9, 0))
+
+        # Mar 2024: 15th is Friday -> fires on 15th
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 3, 15, 9, 0))
+
+    def test_nearest_weekday_saturday(self):
+        # Jun 2024: 15th is Saturday -> fires on Friday 14th
+        base = datetime(2024, 6, 1)
+        itr = croniter("0 9 15W * *", base)
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 6, 14, 9, 0))
+
+    def test_nearest_weekday_sunday(self):
+        # Sep 2024: 15th is Sunday -> fires on Monday 16th
+        base = datetime(2024, 9, 1)
+        itr = croniter("0 9 15W * *", base)
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 9, 16, 9, 0))
+
+    def test_nearest_weekday_first_saturday(self):
+        # 1W: 1st is Saturday -> fires on Monday 3rd (no backward month crossing)
+        # Jun 2024: 1st is Saturday
+        base = datetime(2024, 5, 31)
+        itr = croniter("0 9 1W * *", base)
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 6, 3, 9, 0))
+
+    def test_nearest_weekday_last_day_sunday(self):
+        # 31W in Mar 2025: 31st is Monday -> fires on 31st
+        base = datetime(2025, 3, 1)
+        itr = croniter("0 9 31W * *", base)
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2025, 3, 31, 9, 0))
+
+    def test_nearest_weekday_end_of_month_boundary(self):
+        # 30W in Nov 2024: 30th is Saturday -> fires on Friday 29th
+        base = datetime(2024, 11, 1)
+        itr = croniter("0 9 30W * *", base)
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 11, 29, 9, 0))
+
+        # 31W in a month with only 30 days (Nov): clamps to 30th (Sat) -> Fri 29th
+        base = datetime(2024, 11, 1)
+        itr = croniter("0 9 31W * *", base)
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 11, 29, 9, 0))
+
+    def test_nearest_weekday_wn_format(self):
+        # W15 format (prefix) should work the same as 15W
+        base = datetime(2024, 1, 1)
+        itr = croniter("0 9 W15 * *", base)
+        n = itr.get_next(datetime)
+        self.assertEqual(n, datetime(2024, 1, 15, 9, 0))
+
+    def test_nearest_weekday_get_prev(self):
+        # Test get_prev with W
+        base = datetime(2024, 6, 30)
+        itr = croniter("0 9 15W * *", base)
+        # Jun 2024: 15th is Saturday -> nearest weekday is Friday 14th
+        n = itr.get_prev(datetime)
+        self.assertEqual(n, datetime(2024, 6, 14, 9, 0))
+
+    def test_nearest_weekday_is_valid(self):
+        self.assertTrue(croniter.is_valid("0 9 15W * *"))
+        self.assertTrue(croniter.is_valid("0 9 W15 * *"))
+        self.assertTrue(croniter.is_valid("0 9 1W * *"))
+        self.assertTrue(croniter.is_valid("0 9 31W * *"))
+        # W cannot be used with list or range
+        self.assertFalse(croniter.is_valid("0 9 15W,16 * *"))
+        self.assertFalse(croniter.is_valid("0 9 1,15W * *"))
+        # Out of range
+        self.assertFalse(croniter.is_valid("0 9 0W * *"))
+        self.assertFalse(croniter.is_valid("0 9 32W * *"))
+
+    def test_nearest_weekday_iteration(self):
+        # Test iteration across multiple months
+        base = datetime(2023, 12, 31)
+        itr = croniter("0 0 1W * *", base)
+        results = [itr.get_next(datetime) for _ in range(6)]
+        # Jan 2024: 1st is Mon -> 1st
+        self.assertEqual(results[0], datetime(2024, 1, 1, 0, 0))
+        # Feb 2024: 1st is Thu -> 1st
+        self.assertEqual(results[1], datetime(2024, 2, 1, 0, 0))
+        # Mar 2024: 1st is Fri -> 1st
+        self.assertEqual(results[2], datetime(2024, 3, 1, 0, 0))
+        # Apr 2024: 1st is Mon -> 1st
+        self.assertEqual(results[3], datetime(2024, 4, 1, 0, 0))
+        # May 2024: 1st is Wed -> 1st
+        self.assertEqual(results[4], datetime(2024, 5, 1, 0, 0))
+        # Jun 2024: 1st is Sat -> Mon 3rd
+        self.assertEqual(results[5], datetime(2024, 6, 3, 0, 0))
+
     def test_exactly_the_same_minute(self):
         base = datetime(2018, 3, 5, 12, 30, 50)
         itr = croniter("30 7,12,17 * * *", base)


### PR DESCRIPTION
## Summary
- Add support for `nW` and `Wn` syntax in the day-of-month field (e.g. `"0 9 15W * *"`) to match the nearest weekday (Mon-Fri) to the specified day
- Nearest weekday never crosses month boundaries (1st on Saturday -> Monday 3rd, last day on Sunday -> preceding Friday)
- `W` can only be used with a single day value, not in ranges or lists
- Documentation added to README.rst

Fixes #184

## Test plan
- [x] `test_nearest_weekday_basic` — weekday target fires on that day
- [x] `test_nearest_weekday_saturday` — Saturday -> previous Friday
- [x] `test_nearest_weekday_sunday` — Sunday -> next Monday
- [x] `test_nearest_weekday_first_saturday` — 1st is Saturday -> Monday 3rd (no backward crossing)
- [x] `test_nearest_weekday_last_day_sunday` — last day edge case
- [x] `test_nearest_weekday_end_of_month_boundary` — 30th/31st in short months
- [x] `test_nearest_weekday_wn_format` — `W15` prefix format
- [x] `test_nearest_weekday_get_prev` — reverse iteration
- [x] `test_nearest_weekday_is_valid` — validation (valid, invalid range/list, out of range)
- [x] `test_nearest_weekday_iteration` — iteration across 6 months
- [x] Full test suite passes (134 tests)