### PR TITLE
Add precision_in_seconds parameter to match and match_range

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,19 @@ Test for a match with (>=0.3.32)::
     >>> croniter.match("2 4 1 * wed", datetime(2019, 1, 1, 4, 2, 0, 0), day_or=False) # 04:02 on every 1st day of the month if it is a Wednesday
     False
 
+By default, ``match`` uses a precision of **60 seconds** for standard 5-field cron
+expressions and **1 second** for 6-field expressions (with seconds). This means a
+datetime up to 60 (or 1) seconds after the scheduled time will still match.
+
+You can override this with the ``precision_in_seconds`` parameter::
+
+    >>> # With default precision (60s), 59 seconds past midnight still matches
+    >>> croniter.match("0 0 * * *", datetime(2019, 1, 14, 0, 0, 59, 0))
+    True
+    >>> # With precision=1, only an exact match within 1 second works
+    >>> croniter.match("0 0 * * *", datetime(2019, 1, 14, 0, 0, 59, 0), precision_in_seconds=1)
+    False
+
 Testing if a crontab matches in datetime range
 ==============================================
 Test for a match_range with (>=2.0.3)::
@@ -293,6 +306,8 @@ Test for a match_range with (>=2.0.3)::
     >>> croniter.match_range("2 4 1 * wed", datetime(2019, 1, 1, 3, 2, 0, 0), datetime(2019, 1, 1, 5, 2, 0, 0), day_or=False)
     # 04:02 on every 1st day of the month if it is a Wednesday
     False
+
+The ``precision_in_seconds`` parameter is also available on ``match_range``.
 
 Gaps between date matches
 =========================

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1289,12 +1289,27 @@ class croniter:
         return True
 
     @classmethod
-    def match(cls, cron_expression, testdate, day_or=True, second_at_beginning=False):
-        return cls.match_range(cron_expression, testdate, testdate, day_or, second_at_beginning)
+    def match(
+        cls,
+        cron_expression,
+        testdate,
+        day_or=True,
+        second_at_beginning=False,
+        precision_in_seconds=None,
+    ):
+        return cls.match_range(
+            cron_expression, testdate, testdate, day_or, second_at_beginning, precision_in_seconds
+        )
 
     @classmethod
     def match_range(
-        cls, cron_expression, from_datetime, to_datetime, day_or=True, second_at_beginning=False
+        cls,
+        cron_expression,
+        from_datetime,
+        to_datetime,
+        day_or=True,
+        second_at_beginning=False,
+        precision_in_seconds=None,
     ):
         cron = cls(
             cron_expression,
@@ -1311,7 +1326,8 @@ class croniter:
             tdt = cron.get_prev()
         except CroniterBadDateError:
             return False
-        precision_in_seconds = 1 if len(cron.expanded) > UNIX_CRON_LEN else 60
+        if precision_in_seconds is None:
+            precision_in_seconds = 1 if len(cron.expanded) > UNIX_CRON_LEN else 60
         duration_in_second = (to_datetime - from_datetime).total_seconds() + precision_in_seconds
         return (max(tdp, tdt) - min(tdp, tdt)).total_seconds() < duration_in_second
 

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1400,6 +1400,51 @@ class CroniterTest(base.TestCase):
             croniter.match("0 0 10 * fri", datetime(2020, 6, 12, 0, 0, 0, 0), day_or=False)
         )
 
+    def test_match_precision(self):
+        # Default precision for 5-field cron is 60 seconds
+        # so 59 seconds off still matches
+        self.assertTrue(croniter.match("0 0 * * *", datetime(2019, 1, 14, 0, 0, 59, 0)))
+        # but 61 seconds off does not
+        self.assertFalse(croniter.match("0 0 * * *", datetime(2019, 1, 14, 0, 1, 1, 0)))
+
+        # With explicit precision_in_seconds=1, only exact second matches
+        self.assertTrue(
+            croniter.match("0 0 * * *", datetime(2019, 1, 14, 0, 0, 0, 0), precision_in_seconds=1)
+        )
+        self.assertFalse(
+            croniter.match("0 0 * * *", datetime(2019, 1, 14, 0, 0, 59, 0), precision_in_seconds=1)
+        )
+
+        # Default precision for 6-field cron is 1 second
+        self.assertTrue(croniter.match("0 0 * * * 0", datetime(2019, 1, 14, 0, 0, 0, 0)))
+        self.assertFalse(croniter.match("0 0 * * * 0", datetime(2019, 1, 14, 0, 0, 1, 0)))
+
+        # With explicit precision_in_seconds=60 on a 6-field cron, 59 seconds off matches
+        self.assertTrue(
+            croniter.match(
+                "0 0 * * * 0", datetime(2019, 1, 14, 0, 0, 59, 0), precision_in_seconds=60
+            )
+        )
+
+    def test_match_range_precision(self):
+        # With precision_in_seconds=1, match_range is strict
+        self.assertFalse(
+            croniter.match_range(
+                "0 0 * * *",
+                datetime(2019, 1, 14, 0, 0, 30, 0),
+                datetime(2019, 1, 14, 0, 0, 40, 0),
+                precision_in_seconds=1,
+            )
+        )
+        # With default precision (60s), same range matches
+        self.assertTrue(
+            croniter.match_range(
+                "0 0 * * *",
+                datetime(2019, 1, 14, 0, 0, 30, 0),
+                datetime(2019, 1, 14, 0, 0, 40, 0),
+            )
+        )
+
     def test_match_handle_bad_cron(self):
         # some cron expression can"t get prev value and should not raise exception
         self.assertFalse(croniter.match("0 0 31 1 1#1", datetime(2020, 1, 31), day_or=False))


### PR DESCRIPTION
## Summary
- Add optional `precision_in_seconds` parameter to `croniter.match()` and `croniter.match_range()` to override the default matching precision
- Default behavior is unchanged: 60s for 5-field crons, 1s for 6-field crons
- Document the existing precision behavior and new parameter in the README

Closes #58

## Test plan
- [x] New `test_match_precision` test: verifies default 60s/1s precision and explicit override
- [x] New `test_match_range_precision` test: verifies precision override on `match_range`
- [x] All 136 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)