### PR TITLE
fix: use _last_day_of_month in get_prev to handle leap year Feb 29

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -581,7 +581,9 @@ class croniter:
                     return False, d
 
                 if is_prev:
-                    days_in_prev_month = DAYS[(month - 2) % self.MONTHS_IN_YEAR]
+                    prev_month = (month - 2) % self.MONTHS_IN_YEAR + 1
+                    prev_year = year - 1 if month == 1 else year
+                    days_in_prev_month = _last_day_of_month(prev_year, prev_month)
                     diff_day = nearest_diff_method(d.day, expanded[DAY_FIELD], days_in_prev_month)
                 else:
                     diff_day = nearest_diff_method(d.day, expanded[DAY_FIELD], days)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2220,6 +2220,16 @@ class CroniterTest(base.TestCase):
         ret = croniter("15 22 29 2 *", datetime(2024, 2, 29)).get_prev(datetime)
         self.assertEqual(ret, datetime(2020, 2, 29, 22, 15))
 
+    def test_get_prev_leap_year_feb29(self):
+        """get_prev should not skip Feb 29 on leap years (issue #203)."""
+        expr = "0 0 29 * *"
+        for start in [datetime(2024, 3, 2), datetime(2024, 3, 15), datetime(2024, 3, 28)]:
+            ret = croniter(expr, start).get_prev(datetime)
+            self.assertEqual(ret, datetime(2024, 2, 29))
+        # Also verify from January crosses year boundary correctly
+        ret = croniter(expr, datetime(2024, 1, 15)).get_prev(datetime)
+        self.assertEqual(ret, datetime(2023, 12, 29))
+
     def test_expand_from_start_time_minute(self):
         seven_seconds_interval_pattern = "*/7 * * * *"
         ret1 = croniter(


### PR DESCRIPTION
fix #203 

proc_day_of_month uses the static DAYS tuple to determine the previous month's length when calculating get_prev. Since DAYS hardcodes February as 28 days, get_prev skips Feb 29 in leap years.

This replaces it with _last_day_of_month().
