### PR TITLE
Add License :: OSI Approved :: MIT License classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Recent releases of croniter (6.1.0 and 6.2.0) contain a change to the license information to point to the LICENSE file packaged with the code.  This change broke the license check in home assistant (and probably many other projects).  As the contents of the LICENSE file is the MIT license, this change updates the metadata for pypi to indicate that this package does in fact use the MIT license.