### PR TITLE
Fix outdated Develop section in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -470,7 +470,9 @@ Upgrading
 To 2.0.0
 ---------
 
-- Install or upgrade pytz by using version specified  requirements/base.txt if you have it installed `<=2021.1`.
+
+
+- Install or upgrade pytz if you have it installed `<=2021.1`.
 
 Develop this package
 ====================
@@ -479,11 +481,12 @@ Develop this package
 
     git clone https://github.com/pallets-eco/croniter.git
     cd croniter
-    virtualenv --no-site-packages venv3
-    venv3/bin/pip install --upgrade -r requirements/test.txt -r requirements/lint.txt -r requirements/format.txt -r requirements/tox.txt
-    venv3/bin/black src/
-    venv3/bin/isort src/
-    venv3/bin/tox --current-env -e fmt,lint,test
+
+::
+    uv sync --group dev --group lint --group format --group tox
+    uv run ruff format src/
+    uv run ruff check --fix src/
+    uv run tox -e fmt,lint,test
 
 
 Make a new release

--- a/README.rst
+++ b/README.rst
@@ -476,18 +476,38 @@ To 2.0.0
 
 Develop this package
 ====================
+.. warning::
 
+   Building this project currently requires Python ``>=3.10`` because the pinned
+   ``hatchling`` build backend version requires it.
+   The package itself still supports Python ``>=3.9`` at runtime once installed.
+
+
+Clone the repository
 ::
 
     git clone https://github.com/pallets-eco/croniter.git
     cd croniter
 
+
+Use `uv <https://github.com/astral-sh/uv>`_ to install the dependencies
 ::
+
     uv sync --group dev --group lint --group format --group tox
-    uv run ruff format src/
-    uv run ruff check --fix src/
+
+
+
+
+Now you can run the formatters (``fmt``), linters (``lint``) and tests (``test``) using `tox <https://tox.wiki/en/4.50.1/index.html>`_ through uv.
+::
+
     uv run tox -e fmt,lint,test
 
+Build the package
+=================
+::
+
+    uv build
 
 Make a new release
 ====================


### PR DESCRIPTION
The "Develop this package" section was outdated and contained references to files that no longer exist.

I did the minimal setup locally following the old documentation, the github action `Publish.yml` and a bit of the dockerfiles. I think I got to something that's quite easy, and it's probably going to work for most people.

I'm new to uv so if anything doesn't make sense, please let me know.

I have to say that the release section is still wrong, but I didn't touch it because I'm not sure if it's still being used or not (maybe it can be deleted or rewriten to reflect the current release process). In any case, I believe the standard is to use a virtual environment named `.venv` and not venv3. That alone would break the `release.sh` script.

Oh, and at first I tried doing the full setup with Python 3.9, and it failed due to `hatchling` requirements, but it's possible to only sync the tox group, and all the tests pass, so I guess the library can be used with Python 3.9.

Solves #211 