### PR TITLE
Chore: last day of month explanation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,19 @@ The ``strict`` and ``strict_year`` parameters are also available on ``expand()``
 
     >>> croniter.expand('0 0 31 2 *', strict=True)  # raises CroniterBadCronError
 
+Last day of month (l)
+=====================
+
+You can use ``l`` in the day-of-month field to mean "the last day of the month". This
+automatically respects the number of days in each month, including February and leap years::
+
+    >>> croniter('0 0 l * *', datetime(2024, 1, 30)).get_next(datetime)
+    datetime.datetime(2024, 1, 31, 0, 0)
+    >>> croniter('0 0 l * *', datetime(2024, 2, 1)).get_next(datetime)  # leap year
+    datetime.datetime(2024, 2, 29, 0, 0)
+    >>> croniter('0 0 l * *', datetime(2023, 2, 1)).get_next(datetime)  # non-leap year
+    datetime.datetime(2023, 2, 28, 0, 0)
+
 Nearest weekday (W)
 ===================
 


### PR DESCRIPTION
I came to this repo because I didn't know if I could use "L" in the day of the month for a cron expression. I looked at the code and saw that it was possible. I looked at the tests and saw that there were none that covered February or leap years, so I decided to add them.

Now I know that Croniter handles the last day of the month, even in February, even in leap years.

I hope that the next person that comes with the same question will have an easier time finding the answer.