### PR TITLE
Fix zizmor-reported security findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -13,6 +13,7 @@ env:
   RELEASABLE_REPOS: "^pallets-eco/croniter"
   RELEASABLE_BRANCHES: "^(refs/heads/)?(master|main|new-packaging)$"
   FORCE_COLOR: "true"
+permissions: {}
 jobs:
   test-code-QA:
     runs-on: ubuntu-latest
@@ -22,6 +23,8 @@ jobs:
         python-version: ["3.13"]
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Cache tox environments
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
@@ -48,6 +51,8 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Cache tox environments
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
@@ -70,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Test with pytest
       run: |
          docker compose run --build --rm --env FORCE_COLOR=true --env UV_LINK_MODE=copy app tox -e test

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -10,6 +10,7 @@ env:
   BUILDKIT_PROGRESS: "plain"
   RELEASABLE_REPOS: "^pallets-eco/croniter"
   RELEASABLE_BRANCHES: "^(refs/heads/)?(master|main|new-packaging)$"
+permissions: {}
 jobs:
   docker-build:
     runs-on: ubuntu-24.04
@@ -33,6 +34,8 @@ jobs:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Build
       run: |
         set -ex
@@ -45,7 +48,9 @@ jobs:
     - name: test
       run: set -ex && docker compose run --rm app tox --current-env
     - name: Release
+      env:
+        RELEASABLE: ${{ steps.v.outputs.releasable }}
       run: |
-           if [ "x${{steps.v.outputs.releasable}}" = "xtrue" ];then
-             set -ex && docker push pallets-eco/croniter:${{matrix.FLAVOR}}
+           if [ "x${RELEASABLE}" = "xtrue" ];then
+             set -ex && docker push "pallets-eco/croniter:${FLAVOR}"
            fi

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,6 +16,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
           sarif-upload: true


### PR DESCRIPTION
Addresses all 11 findings reported by zizmor (the scanner wired into `.github/workflows/zizmor.yml`) across the workflows. After the changes, `zizmor .github/workflows/` reports no findings.

- **artipacked (5):** add `persist-credentials: false` to every `actions/checkout` so `GITHUB_TOKEN` isn't persisted into git config / artifacts.
- **excessive-permissions (5):** add top-level `permissions: {}` to `cicd.yml` and `dockerimages.yml` for least-privilege token scopes.
- **template-injection (1):** in `dockerimages.yml` Release step, pass `steps.v.outputs.releasable` via an `env:` var and use the existing `$FLAVOR` env var instead of interpolating `${{ }}` into the shell.

Workflow/config changes only.