### PR TITLE
reject zero step in equal and reversed cron ranges

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1049,6 +1049,11 @@ class croniter:
                             f" in field {field_index} is not acceptable"
                         )
                     step = int(step)
+                    if step == 0:
+                        raise CroniterBadCronError(
+                            f"[{expr_format}] step '{step}'"
+                            f" in field {field_index} is not acceptable"
+                        )
 
                     for band in low, high:
                         if not only_int_re.search(str(band)):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1321,6 +1321,13 @@ class CroniterTest(base.TestCase):
 
     def test_invalid_zerorepeat(self):
         self.assertFalse(croniter.is_valid("*/0 * * * *"))
+        # a zero step must be rejected the same way in every range form, not
+        # only `*/0`/`low-high/0` (low < high).  `low == high` and the reversed
+        # `low > high` forms previously reached `range(..., 0)` and surfaced a
+        # bare `ValueError` out of the constructor instead of CroniterBadCronError.
+        for expr in ("5-5/0 * * * *", "59-0/0 * * * *", "* * 31-1/0 * *", "* * * * 6-0/0"):
+            self.assertFalse(croniter.is_valid(expr))
+            self.assertRaises(CroniterBadCronError, croniter, expr, datetime(2020, 1, 1))
 
     def test_weekday_range(self):
         ret = []


### PR DESCRIPTION
Repro: `croniter("5-5/0 * * * *")` (also `59-0/0 * * * *`, `* * 31-1/0 * *`).
Expected: `CroniterBadCronError`, same as `croniter("*/0 * * * *")` and the `H/0` hash form already give.
Actual: a bare `ValueError: range() arg 3 must not be zero` leaks out of the constructor.
Cause: only the `low < high` branch of `_expand` guards its `range(low, high + 1, step)` under a `try`. The `low == high` and reversed `low > high` branches call `range(..., step)` with no guard, so a `/0` step reaches `range()` directly. The same zero step also hits a modulo-by-zero in `_get_low_from_current_date_number` on the `expand_from_start_time` path.
Fix: reject `step == 0` once where the step is parsed, so every range form is rejected as `CroniterBadCronError` like `*/0` and `H/0` already are. `is_valid` already returned `False` for these (the `expand` wrapper coerces the `ValueError`), but the constructor did not.