### PR TITLE
fix expand_from_start_time month low bound off-by-one

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1273,7 +1273,7 @@ class croniter:
         if field_index == DAY_FIELD:
             return ((dt.day - 1) % step) + 1
         if field_index == MONTH_FIELD:
-            return dt.month % step
+            return ((dt.month - 1) % step) + 1
         if field_index == DOW_FIELD:
             return (dt.weekday() + 1) % step
 

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2379,6 +2379,24 @@ class CroniterTest(base.TestCase):
         ).get_prev(datetime)
         self.assertEqual(ret4, datetime(2024, 5, 1))
 
+    def test_expand_from_start_time_month_divisible(self):
+        # A start month that is a multiple of the step (here 6 % 3 == 0) must
+        # still expand to a valid 1-12 month, not month 0.
+        three_monts_interval_pattern = "0 0 1 */3 *"
+        ret1 = croniter(
+            three_monts_interval_pattern,
+            start_time=datetime(2024, 6, 1),
+            expand_from_start_time=True,
+        ).get_next(datetime)
+        self.assertEqual(ret1, datetime(2024, 9, 1))
+
+        ret2 = croniter(
+            three_monts_interval_pattern,
+            start_time=datetime(2024, 6, 1),
+            expand_from_start_time=True,
+        ).get_prev(datetime)
+        self.assertEqual(ret2, datetime(2024, 3, 1))
+
     def test_expand_from_start_time_day_of_week(self):
         three_monts_interval_pattern = "0 0 * * */2"
         ret1 = croniter(


### PR DESCRIPTION
Repro: `croniter("0 0 1 */3 *", datetime(2024, 6, 1), expand_from_start_time=True)` raises `CroniterBadCronError: is not acceptable, out of range`. Any start month that is a multiple of the step (`6 % 3 == 0`, so also March/September/December) hits it, while the same expression parses fine without `expand_from_start_time`.

Cause: `_get_low_from_current_date_number` returns `dt.month % step` for the month field, but months are 1-based (`1`-`12`) unlike the 0-based minute/hour fields. When the month divides evenly by the step the helper yields `0`, which `_expand` then rejects as out of range. The day-of-month branch, also 1-based, already uses `((dt.day - 1) % step) + 1`.

Fix: mirror the day branch for month, `((dt.month - 1) % step) + 1`, keeping the low bound in `1`-`12`. The existing `test_expand_from_start_time_month` only exercised start months `7` and `8`, both non-multiples of `3`, so the case was untested.