### PR TITLE
wrap sunday in expand_from_start_time day-of-week low bound

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1280,7 +1280,7 @@ class croniter:
         if field_index == MONTH_FIELD:
             return ((dt.month - 1) % step) + 1
         if field_index == DOW_FIELD:
-            return (dt.weekday() + 1) % step
+            return (dt.isoweekday() % 7) % step
 
         raise ValueError("Can't get current date number for index larger than 4")
 

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2434,6 +2434,35 @@ class CroniterTest(base.TestCase):
         ).get_prev(datetime)
         self.assertEqual(ret4, datetime(2024, 7, 9))
 
+    def test_expand_from_start_time_day_of_week_sunday(self):
+        # A Sunday start (cron day-of-week 0) must keep Sunday in a */step
+        # schedule.  Sunday is isoweekday 7, so it has to wrap to 0 before the
+        # step modulo, otherwise the phase is computed from 7 and Sunday drops
+        # out of the expansion.
+        every_other_dow = "0 0 * * */2"
+        ret1 = croniter(
+            every_other_dow,
+            start_time=datetime(2024, 7, 14),  # Sunday
+            expand_from_start_time=True,
+        ).get_next(datetime)
+        self.assertEqual(ret1, datetime(2024, 7, 16))
+
+        ret2 = croniter(
+            every_other_dow,
+            start_time=datetime(2024, 7, 14),
+            expand_from_start_time=True,
+        ).get_prev(datetime)
+        self.assertEqual(ret2, datetime(2024, 7, 13))
+
+        # The phased schedule still fires on Sundays.
+        itr = croniter(
+            every_other_dow,
+            start_time=datetime(2024, 7, 14),
+            expand_from_start_time=True,
+        )
+        fires = [itr.get_next(datetime) for _ in range(4)]
+        self.assertIn(datetime(2024, 7, 21), fires)
+
     def test_get_next_fails_with_expand_from_start_time_true(self):
         expanded_croniter = croniter("0 0 */5 * *", expand_from_start_time=True)
         self.assertRaises(


### PR DESCRIPTION
Repro: `croniter("0 0 * * */2", datetime(2024, 7, 14), expand_from_start_time=True)`, where the start is a Sunday.
Expected: Sunday stays in the schedule the way `expand_from_start_time` keeps the start value for the other fields, so the day-of-week set is `[0, 2, 4, 6]` and `get_next` gives Tuesday `2024-07-16`.
Actual: the set is `[1, 3, 5]` and `get_next` gives Monday `2024-07-15`, so Sunday (the start weekday) never fires.
Cause: `_get_low_from_current_date_number` phases the day-of-week low bound with `(dt.weekday() + 1) % step`. `dt.weekday()` is `0`=Mon..`6`=Sun, so a Sunday start yields `7`, but cron day-of-week numbering is `0`=Sun..`6`=Sat, so the value has to wrap to `0` before the step modulo. `7 % step` equals `0 % step` only when `step` divides `7`, so steps `2`-`6` shift the phase and drop Sunday. `proc_day_of_week` already uses `d.isoweekday() % 7` for the same conversion.
Fix: mirror it with `(dt.isoweekday() % 7) % step`. Unchanged for Mon-Sat, only the Sunday case moves. The existing `test_expand_from_start_time_day_of_week` only used Wednesday and Thursday starts, so the Sunday case was untested.