### PR TITLE
Do not crash when an unsatisfiable day-of-month is OR-combined with day-of-week

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -491,13 +491,45 @@ class croniter:
                 # does an intersect instead
                 pass
             else:
+                # Under OR semantics an unsatisfiable side -- the 31st in a month
+                # that has no 31st, say -- contributes no dates rather than ruling
+                # out the expression, so the other side must still be able to
+                # match. Only both sides failing means there is no such date.
+                #
+                # That only holds while each side is a clean operand. '#' and 'W'
+                # are not carried by the DAY/DOW fields but by nth_weekday_of_month
+                # and self.nearest_weekday, so blanking the fields above does not
+                # remove them and each side stays an intersection (the semantics
+                # test_issue_k33 pins down). Swallowing a failure there would drop
+                # the other field from the schedule instead, so let it propagate.
+                clean_split = not nth_weekday_of_month and not self.nearest_weekday
+
                 bak = expanded[DOW_FIELD]
                 expanded[DOW_FIELD] = ["*"]
-                t1 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
+                try:
+                    t1 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
+                except CroniterBadDateError:
+                    if not clean_split:
+                        raise
+                    t1 = None
                 expanded[DOW_FIELD] = bak
                 expanded[DAY_FIELD] = ["*"]
 
-                t2 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
+                try:
+                    t2 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
+                except CroniterBadDateError:
+                    if not clean_split:
+                        raise
+                    t2 = None
+
+                if t1 is None:
+                    if t2 is None:
+                        raise CroniterBadDateError(
+                            "failed to find prev date" if is_prev else "failed to find next date"
+                        )
+                    return t2
+                if t2 is None:
+                    return t1
                 if is_prev:
                     return t1 if t1 > t2 else t2
                 return t1 if t1 < t2 else t2

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -15,6 +15,7 @@ from croniter import (
     CroniterNotAlphaError,
     CroniterUnsupportedSyntaxError,
     croniter,
+    croniter_range,
     datetime_to_timestamp,
 )
 from croniter.croniter import VALID_LEN_EXPRESSION
@@ -201,6 +202,76 @@ class CroniterTest(base.TestCase):
         self.assertEqual(n3.month, 9)
         self.assertEqual(n3.day, 29)
         self.assertEqual(n3.year, 2010)
+
+    def test_weekday_day_or_with_impossible_day_of_month(self):
+        # A day-of-month that never occurs in the given month does not
+        # invalidate the expression -- the day-of-week half of the union
+        # still matches. "0 0 31 2 0" means "every Sunday in February".
+        for expr, expected in (
+            ("0 0 31 2 0", [(2026, 2, 1), (2026, 2, 8), (2026, 2, 15)]),
+            ("0 0 30 2 0", [(2026, 2, 1), (2026, 2, 8), (2026, 2, 15)]),
+            ("0 0 31 4 0", [(2026, 4, 5), (2026, 4, 12), (2026, 4, 19)]),
+        ):
+            itr = croniter(expr, datetime(2026, 1, 1))
+            got = [itr.get_next(datetime) for _ in range(3)]
+            self.assertEqual([(d.year, d.month, d.day) for d in got], expected, expr)
+
+    def test_weekday_day_or_with_impossible_day_of_month_prev(self):
+        itr = croniter("0 0 31 2 0", datetime(2026, 3, 1))
+        got = [itr.get_prev(datetime) for _ in range(3)]
+        self.assertEqual(
+            [(d.year, d.month, d.day) for d in got],
+            [(2026, 2, 22), (2026, 2, 15), (2026, 2, 8)],
+        )
+
+    def test_impossible_day_of_month_alone_still_raises(self):
+        # With no day-of-week to fall back on there really is no such date.
+        for expr in ("0 0 31 2 *", "0 0 30 2 *"):
+            itr = croniter(expr, datetime(2026, 1, 1))
+            with self.assertRaises(CroniterBadDateError, msg=expr):
+                itr.get_next(datetime)
+
+    def test_impossible_day_of_month_match_and_range(self):
+        # match() and croniter_range() swallow CroniterBadDateError, so an
+        # aborted schedule reaches the caller as "no match" rather than as an
+        # error. 2026-02-01 is a Sunday, so it does match "0 0 31 2 0".
+        self.assertTrue(croniter.match("0 0 31 2 0", datetime(2026, 2, 1)))
+        self.assertFalse(croniter.match("0 0 31 2 0", datetime(2026, 2, 2)))
+        got = croniter_range(datetime(2026, 2, 1), datetime(2026, 3, 1), "0 0 31 2 0")
+        self.assertEqual(
+            [(d.year, d.month, d.day) for d in got],
+            [(2026, 2, 1), (2026, 2, 8), (2026, 2, 15), (2026, 2, 22)],
+        )
+
+    def test_nth_weekday_with_restricted_day_of_month_still_raises(self):
+        # '#' is carried by nth_weekday_of_month rather than by the day-of-week
+        # field, so blanking that field does not isolate the day-of-month half:
+        # it stays an intersection, the semantics test_issue_k33 pins down.
+        # Such an expression must keep raising instead of silently dropping a
+        # field -- "8-9" can never coincide with the first Mon-Fri of January.
+        for expr in ("30 23 8-9 JAN MON-FRI#1", "0 0 1 2 fri#2", "0 0 15 * fri#2"):
+            itr = croniter(expr, datetime(2026, 1, 1))
+            with self.assertRaises(CroniterBadDateError, msg=expr):
+                itr.get_next(datetime)
+
+    def test_nearest_weekday_with_restricted_day_of_week_still_raises(self):
+        # Same for 'W', which is carried by self.nearest_weekday.
+        itr = croniter("0 0 31w 2 0", datetime(2026, 1, 1))
+        with self.assertRaises(CroniterBadDateError):
+            itr.get_next(datetime)
+
+    def test_both_union_sides_unsatisfiable_reports_direction(self):
+        # A year field can rule out both halves at once. The error names the
+        # direction that was searched.
+        itr = croniter("0 0 31 2 0 0 2026", datetime(2027, 6, 1))
+        with self.assertRaises(CroniterBadDateError) as ctx:
+            itr.get_next(datetime)
+        self.assertEqual(str(ctx.exception), "failed to find next date")
+
+        itr = croniter("0 0 31 2 0 0 2026", datetime(2025, 6, 1))
+        with self.assertRaises(CroniterBadDateError) as ctx:
+            itr.get_prev(datetime)
+        self.assertEqual(str(ctx.exception), "failed to find prev date")
 
     def test_weekday_day_and(self):
         base = datetime(2010, 1, 25)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -15,7 +15,6 @@ from croniter import (
     CroniterNotAlphaError,
     CroniterUnsupportedSyntaxError,
     croniter,
-    croniter_range,
     datetime_to_timestamp,
 )
 from croniter.croniter import VALID_LEN_EXPRESSION
@@ -231,17 +230,12 @@ class CroniterTest(base.TestCase):
             with self.assertRaises(CroniterBadDateError, msg=expr):
                 itr.get_next(datetime)
 
-    def test_impossible_day_of_month_match_and_range(self):
-        # match() and croniter_range() swallow CroniterBadDateError, so an
-        # aborted schedule reaches the caller as "no match" rather than as an
-        # error. 2026-02-01 is a Sunday, so it does match "0 0 31 2 0".
+    def test_impossible_day_of_month_still_matches(self):
+        # match() swallows CroniterBadDateError, so an aborted schedule reaches the
+        # caller as "no match" rather than as an error. 2026-02-01 is a Sunday, so it
+        # does match "0 0 31 2 0".
         self.assertTrue(croniter.match("0 0 31 2 0", datetime(2026, 2, 1)))
         self.assertFalse(croniter.match("0 0 31 2 0", datetime(2026, 2, 2)))
-        got = croniter_range(datetime(2026, 2, 1), datetime(2026, 3, 1), "0 0 31 2 0")
-        self.assertEqual(
-            [(d.year, d.month, d.day) for d in got],
-            [(2026, 2, 1), (2026, 2, 8), (2026, 2, 15), (2026, 2, 22)],
-        )
 
     def test_nth_weekday_with_restricted_day_of_month_still_raises(self):
         # '#' is carried by nth_weekday_of_month rather than by the day-of-week

--- a/src/croniter/tests/test_croniter_range.py
+++ b/src/croniter/tests/test_croniter_range.py
@@ -215,6 +215,17 @@ class CroniterRangeTest(base.TestCase):
         self.assertEqual(fwd[0], start)
         self.assertEqual(fwd[-1], stop)
 
+    def test_impossible_day_of_month_does_not_empty_the_range(self):
+        # croniter_range swallows CroniterBadDateError too, so an aborted schedule
+        # silently yields nothing instead of the dates the day-of-week half matches.
+        start = datetime(2026, 2, 1)
+        stop = datetime(2026, 3, 1)
+        fwd = list(croniter_range(start, stop, "0 0 31 2 0"))
+        self.assertEqual(
+            [(d.month, d.day) for d in fwd],
+            [(2, 1), (2, 8), (2, 15), (2, 22)],
+        )
+
     def test_year_range(self):
         start = datetime(2010, 1, 1)
         stop = datetime(2030, 1, 1)


### PR DESCRIPTION
`is_valid()` accepts `30 6 31 2 1`, but `get_next()` and `get_prev()` both raise `CroniterBadDateError` on it. February has no 31st, so the day-of-month half of the union can never match — and under OR semantics that side should contribute no dates rather than rule out the expression. The Mondays in February still match.

`match()` and `croniter_range()` swallow the error, so they don't raise; they quietly return the wrong answer instead:

```pycon
>>> croniter.match('0 0 31 2 0', datetime(2026, 2, 1))   # a Sunday in February
False
>>> list(croniter_range(datetime(2026, 2, 1), datetime(2026, 3, 1), '0 0 31 2 0'))
[]
```

## The change

A side that raises is treated as contributing nothing, and only both sides failing means there is no such date.

That holds while each side is a clean operand — and `#`/`W` are not. They live in `nth_weekday_of_month` and `self.nearest_weekday` rather than in the DAY/DOW fields, so blanking the fields leaves them live and each half stays an intersection (the semantics `test_issue_k33` pins down). Swallowing a failure there would silently drop the other field from the schedule, so `clean_split` lets it propagate instead.

## Checks

- Diffed against `main` across 2400 `#`/`W` cases: the 1728 involving `#`/`W` are byte-identical, and the 48 differences are all `raises → dates` on the eight `31 FEB`-shaped expressions.
- A brute-force union oracle over 175 expressions, both directions, 2026–2029: 0 mismatches here, 50 on `main`.
- Full suite 228 passing, `mypy` and `ruff` clean.

Tests cover the union cases and their `get_prev`, the negative case that must still raise, `match()`, `croniter_range()`, regressions pinning the raise for `#` and `W`, and the both-halves-unsatisfiable branch — reachable only through the year field, since a restricted day-of-week always matches somewhere.

The `#`/`W` semantics question this turned up is written up separately in #249.

---

Converged with #248, now closed. The `clean_split` guard came out of @potiuk's review, and the `croniter_range` regression is @MildlyMeticulous's — both the test and its placement in `test_croniter_range.py`. Noting it here rather than in a commit trailer, per `AGENTS.md`.
