### PR TITLE
fix: DOM/DOW union fails when only the day-of-month half is unsatisfiable

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -493,11 +493,26 @@ class croniter:
             else:
                 bak = expanded[DOW_FIELD]
                 expanded[DOW_FIELD] = ["*"]
-                t1 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
+                # Either side of the union may be unsatisfiable on its own -- e.g.
+                # day 31 in February. That only rules out the whole expression if
+                # the other side is unsatisfiable too.
+                try:
+                    t1 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
+                except CroniterBadDateError:
+                    t1 = None
                 expanded[DOW_FIELD] = bak
                 expanded[DAY_FIELD] = ["*"]
 
-                t2 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
+                try:
+                    t2 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
+                except CroniterBadDateError:
+                    t2 = None
+                if t1 is None or t2 is None:
+                    if t1 is None and t2 is None:
+                        raise CroniterBadDateError(
+                            "failed to find prev date" if is_prev else "failed to find next date"
+                        )
+                    return t1 if t2 is None else t2
                 if is_prev:
                     return t1 if t1 > t2 else t2
                 return t1 if t1 < t2 else t2

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -491,14 +491,15 @@ class croniter:
                 # does an intersect instead
                 pass
             else:
+                split_is_clean = not nth_weekday_of_month and not self.nearest_weekday
+
                 bak = expanded[DOW_FIELD]
                 expanded[DOW_FIELD] = ["*"]
-                # Either side of the union may be unsatisfiable on its own -- e.g.
-                # day 31 in February. That only rules out the whole expression if
-                # the other side is unsatisfiable too.
                 try:
                     t1 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
                 except CroniterBadDateError:
+                    if not split_is_clean:
+                        raise
                     t1 = None
                 expanded[DOW_FIELD] = bak
                 expanded[DAY_FIELD] = ["*"]
@@ -506,13 +507,18 @@ class croniter:
                 try:
                     t2 = self._calc(current, expanded, nth_weekday_of_month, is_prev)
                 except CroniterBadDateError:
+                    if not split_is_clean:
+                        raise
                     t2 = None
-                if t1 is None or t2 is None:
-                    if t1 is None and t2 is None:
+
+                if t1 is None:
+                    if t2 is None:
                         raise CroniterBadDateError(
                             "failed to find prev date" if is_prev else "failed to find next date"
                         )
-                    return t1 if t2 is None else t2
+                    return t2
+                if t2 is None:
+                    return t1
                 if is_prev:
                     return t1 if t1 > t2 else t2
                 return t1 if t1 < t2 else t2

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -202,6 +202,34 @@ class CroniterTest(base.TestCase):
         self.assertEqual(n3.day, 29)
         self.assertEqual(n3.year, 2010)
 
+    def test_weekday_day_or_with_impossible_day_of_month(self):
+        # A day-of-month that never occurs in the given month does not
+        # invalidate the expression -- the day-of-week half of the union
+        # still matches. "0 0 31 2 0" means "every Sunday in February".
+        for expr, expected in (
+            ("0 0 31 2 0", [(2026, 2, 1), (2026, 2, 8), (2026, 2, 15)]),
+            ("0 0 30 2 0", [(2026, 2, 1), (2026, 2, 8), (2026, 2, 15)]),
+            ("0 0 31 4 0", [(2026, 4, 5), (2026, 4, 12), (2026, 4, 19)]),
+        ):
+            itr = croniter(expr, datetime(2026, 1, 1))
+            got = [itr.get_next(datetime) for _ in range(3)]
+            self.assertEqual([(d.year, d.month, d.day) for d in got], expected, expr)
+
+    def test_weekday_day_or_with_impossible_day_of_month_prev(self):
+        itr = croniter("0 0 31 2 0", datetime(2026, 3, 1))
+        got = [itr.get_prev(datetime) for _ in range(3)]
+        self.assertEqual(
+            [(d.year, d.month, d.day) for d in got],
+            [(2026, 2, 22), (2026, 2, 15), (2026, 2, 8)],
+        )
+
+    def test_impossible_day_of_month_alone_still_raises(self):
+        # With no day-of-week to fall back on there really is no such date.
+        for expr in ("0 0 31 2 *", "0 0 30 2 *"):
+            itr = croniter(expr, datetime(2026, 1, 1))
+            with self.assertRaises(CroniterBadDateError, msg=expr):
+                itr.get_next(datetime)
+
     def test_weekday_day_and(self):
         base = datetime(2010, 1, 25)
         itr = croniter("0 0 1 * mon", base, day_or=False)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -203,9 +203,6 @@ class CroniterTest(base.TestCase):
         self.assertEqual(n3.year, 2010)
 
     def test_weekday_day_or_with_impossible_day_of_month(self):
-        # A day-of-month that never occurs in the given month does not
-        # invalidate the expression -- the day-of-week half of the union
-        # still matches. "0 0 31 2 0" means "every Sunday in February".
         for expr, expected in (
             ("0 0 31 2 0", [(2026, 2, 1), (2026, 2, 8), (2026, 2, 15)]),
             ("0 0 30 2 0", [(2026, 2, 1), (2026, 2, 8), (2026, 2, 15)]),
@@ -224,8 +221,23 @@ class CroniterTest(base.TestCase):
         )
 
     def test_impossible_day_of_month_alone_still_raises(self):
-        # With no day-of-week to fall back on there really is no such date.
         for expr in ("0 0 31 2 *", "0 0 30 2 *"):
+            itr = croniter(expr, datetime(2026, 1, 1))
+            with self.assertRaises(CroniterBadDateError, msg=expr):
+                itr.get_next(datetime)
+
+    def test_match_with_impossible_day_of_month(self):
+        self.assertTrue(croniter.match("0 0 31 2 0", datetime(2026, 2, 1)))
+        self.assertFalse(croniter.match("0 0 31 2 0", datetime(2026, 2, 2)))
+
+    def test_nth_weekday_with_restricted_day_of_month_still_raises(self):
+        for expr in ("30 23 8-9 JAN MON-FRI#1", "0 0 1 2 fri#2", "0 0 15 * fri#2"):
+            itr = croniter(expr, datetime(2026, 1, 1))
+            with self.assertRaises(CroniterBadDateError, msg=expr):
+                itr.get_next(datetime)
+
+    def test_nearest_weekday_with_restricted_day_of_week_still_raises(self):
+        for expr in ("0 0 15w * 0", "0 0 31w 2 0"):
             itr = croniter(expr, datetime(2026, 1, 1))
             with self.assertRaises(CroniterBadDateError, msg=expr):
                 itr.get_next(datetime)

--- a/src/croniter/tests/test_croniter_range.py
+++ b/src/croniter/tests/test_croniter_range.py
@@ -215,6 +215,15 @@ class CroniterRangeTest(base.TestCase):
         self.assertEqual(fwd[0], start)
         self.assertEqual(fwd[-1], stop)
 
+    def test_impossible_day_of_month_does_not_empty_the_range(self):
+        start = datetime(2026, 2, 1)
+        stop = datetime(2026, 3, 1)
+        fwd = list(croniter_range(start, stop, "0 0 31 2 0"))
+        self.assertEqual(
+            [(d.month, d.day) for d in fwd],
+            [(2, 1), (2, 8), (2, 15), (2, 22)],
+        )
+
     def test_year_range(self):
         start = datetime(2010, 1, 1)
         stop = datetime(2030, 1, 1)


### PR DESCRIPTION
### The bug

```pycon
>>> from croniter import croniter
>>> import datetime as dt
>>> croniter("0 0 31 2 0", dt.datetime(2026, 1, 1)).get_next(dt.datetime)
croniter.croniter.CroniterBadDateError: failed to find next date
```

`0 0 31 2 0` is day-of-month 31, month February, day-of-week Sunday. Both day fields are restricted, so per Vixie cron they form a **union**: the expression means *"February 31st **or** any Sunday in February"*. February 31st never happens, but Sundays in February certainly do, so the correct answer is `2026-02-01`.

Affected expressions are those where the day-of-month can never occur in the selected month, while a day-of-week is also given:

| expression | croniter | correct |
|---|---|---|
| `0 0 31 2 0` | `CroniterBadDateError` | 2026-02-01, 02-08, 02-15 |
| `0 0 30 2 0` | `CroniterBadDateError` | 2026-02-01, 02-08, 02-15 |
| `0 0 31 4 0` | `CroniterBadDateError` | 2026-04-05, 04-12, 04-19 |

Neighbouring cases already work, which is what makes this look like an oversight rather than a decision — `0 0 29 2 0` is fine (Feb 29 exists in leap years) and `0 0 31 1 0` is fine (Jan 31 exists), so only the *never-possible* day-of-month trips it.

### Cause

In `_calc_next`:

```python
bak = expanded[DOW_FIELD]
expanded[DOW_FIELD] = ["*"]
t1 = self._calc(current, expanded, nth_weekday_of_month, is_prev)   # DOM side
expanded[DOW_FIELD] = bak
expanded[DAY_FIELD] = ["*"]

t2 = self._calc(current, expanded, nth_weekday_of_month, is_prev)   # DOW side
if is_prev:
    return t1 if t1 > t2 else t2
return t1 if t1 < t2 else t2
```

The union is implemented as "compute both, take the earlier". But when the DOM side is unsatisfiable, `_calc` raises `CroniterBadDateError` on the `t1` line — so the DOW side is never even computed, and the error escapes. An empty operand in a union should contribute nothing, not annihilate the result.

### Fix

Catch `CroniterBadDateError` on each side independently and only re-raise when **both** are unsatisfiable.

`0 0 31 2 *` (impossible day-of-month, no day-of-week to fall back on) still raises, as it should — that's the case from #141.

### Verification

Cross-checked against two independent references, which agree with each other and with this patch:

- a brute-force matcher that walks minute by minute and applies the POSIX union rule directly
- the [`cron-parser`](https://github.com/harrisiirak/cron-parser) npm package

```
0 0 31 2 0  -> 2026-02-01 2026-02-08 2026-02-15
0 0 30 2 0  -> 2026-02-01 2026-02-08 2026-02-15
0 0 31 4 0  -> 2026-04-05 2026-04-12 2026-04-19
0 0 31 2 *  -> Invalid explicit day of month definition
```

`get_prev` was checked too and is symmetric: from 2026-03-01, `0 0 31 2 0` walks back 2026-02-22, 02-15, 02-08.

3 tests added. Against the unpatched `croniter.py` **2 of them fail**; with the patch the suite goes from 216 to 219 passing.

The 4 failing + 4 erroring tests in `test_croniter_dst_repetition.py` are **pre-existing on this machine** and unrelated — identical counts before and after the change (they depend on the local timezone).

I found this while differential-testing croniter against a brute-force reference over ~600 generated expressions; this was the only class of disagreement.
