### PR TITLE
Readability pass on core croniter parser

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -326,11 +326,13 @@ class croniter:
         self.cur = 0.0
         self.set_current(start_time, force=True)
 
-        self.expanded, self.nth_weekday_of_month, self.expressions, self.nearest_weekday = self._expand(
-            expr_format,
-            hash_id=hash_id,
-            from_timestamp=self.dst_start_time if self._expand_from_start_time else None,
-            second_at_beginning=second_at_beginning,
+        self.expanded, self.nth_weekday_of_month, self.expressions, self.nearest_weekday = (
+            self._expand(
+                expr_format,
+                hash_id=hash_id,
+                from_timestamp=self.dst_start_time if self._expand_from_start_time else None,
+                second_at_beginning=second_at_beginning,
+            )
         )
         self.fields = CRON_FIELDS[len(self.expanded)]
         self._is_prev = is_prev
@@ -531,8 +533,8 @@ class croniter:
                 if t2 is None:
                     return t1
                 if is_prev:
-                    return t1 if t1 > t2 else t2
-                return t1 if t1 < t2 else t2
+                    return max(t1, t2)
+                return min(t1, t2)
 
         return self._calc(current, expanded, nth_weekday_of_month, is_prev)
 
@@ -938,10 +940,31 @@ class croniter:
         return val
 
     # Maximum days in each month (non-leap year for Feb)
-    DAYS_IN_MONTH = {1: 31, 2: 28, 3: 31, 4: 30, 5: 31, 6: 30, 7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31}
+    DAYS_IN_MONTH = {
+        1: 31,
+        2: 28,
+        3: 31,
+        4: 30,
+        5: 31,
+        6: 30,
+        7: 31,
+        8: 31,
+        9: 30,
+        10: 31,
+        11: 30,
+        12: 31,
+    }
 
     @classmethod
-    def _expand(cls, expr_format, hash_id=None, second_at_beginning=False, from_timestamp=None, strict=False, strict_year=None):
+    def _expand(
+        cls,
+        expr_format,
+        hash_id=None,
+        second_at_beginning=False,
+        from_timestamp=None,
+        strict=False,
+        strict_year=None,
+    ):
         # Split the expression in components, and normalize L -> l, MON -> mon,
         # etc. Keep expr_format untouched so we can use it in the exception
         # messages.
@@ -1317,14 +1340,28 @@ class croniter:
         raise ValueError("Can't get current date number for index larger than 4")
 
     @classmethod
-    def is_valid(cls, expression, hash_id=None, encoding="UTF-8", second_at_beginning=False, strict=False, strict_year=None):
+    def is_valid(
+        cls,
+        expression,
+        hash_id=None,
+        encoding="UTF-8",
+        second_at_beginning=False,
+        strict=False,
+        strict_year=None,
+    ):
         if hash_id:
             if not isinstance(hash_id, (bytes, str)):
                 raise TypeError("hash_id must be bytes or UTF-8 string")
             if not isinstance(hash_id, bytes):
                 hash_id = hash_id.encode(encoding)
         try:
-            cls.expand(expression, hash_id=hash_id, second_at_beginning=second_at_beginning, strict=strict, strict_year=strict_year)
+            cls.expand(
+                expression,
+                hash_id=hash_id,
+                second_at_beginning=second_at_beginning,
+                strict=strict,
+                strict_year=strict_year,
+            )
         except CroniterError:
             return False
         return True


### PR DESCRIPTION
I use croniter in scheduling tooling and wanted to contribute a small readability pass on the core parser while running ShipGate on the repo for a broader quality picture.

## Summary

**Repo health:** 55/100

ShipGate reported **0 format issues** and **~225 refactoring opportunities** (strict pass) on a full-repo scan. Security scans and duplication checks were clean; the main themes are maintainability complexity in the large `croniter.py` module, dependency-metadata noise from deptry, and YAML workflow lint in CI configs. This PR applies a focused auto-fix pass on the production package only — the codebase was already ruff-formatted, so changes are intentionally narrow.

Hotspots and improvement notes below are scoped to **Python (`*.py`)** source.

## What you are doing right

- **Security:** No secrets or high-severity security patterns flagged (gitleaks/bandit/semgrep clean in scope).
- **Duplication:** No significant clone duplication reported — jscpd looked clean.
- **Test discipline:** 228 tests pass locally with **95%** coverage on `croniter.py`; tox lint, mypy, and ruff format all green.
- **Tooling:** Modern ruff + mypy + tox/uv CI matrix across Python 3.9–3.13 is solid.
- **Packaging:** Clear `src/` layout with hatchling; dev groups for lint/format/mypy are well organized.

## What you could improve

- **Maintainability / complexity:** `croniter._expand` and `_calc` rank F/D on cyclomatic complexity — the module is large (~1,300 lines). Consider incremental extraction of field-expansion helpers over time.
- **Dependencies (deptry):** `python_dateutil` is declared but deptry flags import naming (`dateutil` vs package name); `pytz` is used in production code but listed only under dev deps — worth aligning metadata if you want cleaner deptry/pip-audit signal.
- **Dead code / structure:** Several module-level helpers (`_last_day_of_month`, `_timezone_delta`, etc.) are only used by `croniter` — moving them to `@staticmethod` would tighten encapsulation (not in this PR).
- **Refactoring (follow-up):** ~225 strict refactor hints remain — mostly style simplifications in tests and the core parser; many are optional.
- **CI YAML (yamllint):** Workflow files have quoted-string and indentation style findings from yamllint — cosmetic; deferred to avoid unrelated CI churn.

## Changes

| Pass | Files | Fixes / rules | Manual? |
| --- | --- | --- | --- |
| `shipgate format --target src/croniter` | 0 | already formatted | no |
| `shipgate refactor fix src/croniter` | 1 | `min-max-identity`, line-wrap readability | no |
| `ruff check --fix` (project config) | 0 | all checks passed | no |
| **Total** | **1** | | **0** |

- Replace conditional `min`/`max` comparisons with `min()` / `max()` in `_calc_next`.
- Wrap long `_expand` / `is_valid` signatures and `DAYS_IN_MONTH` dict for readability (ruff line-length alignment).

**Note:** Auto-fix budget was 90s (core LOC 5,980 → floor); the production tree was already formatter-clean, so this PR stays intentionally small rather than touching tests or CI YAML.

---
*We're testing [ShipGate](https://github.com/inquilabee/shipgate) on real-world projects to learn whether it works well in practice. This review summary was generated from ShipGate check output and AI-assisted analysis. Feedback on the findings or approach is welcome and appreciated — [docs](https://inquilabee.github.io/shipgate/).*

*Full ShipGate findings:* [review gist](https://gist.github.com/inquilabee/b97ab9bf037db335465bd6d5537dc691)