### PR TITLE
Fix hashed divisions when the divisor is wider than its range

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ Changelog
 Bugfixes
 ~~~~~~~~
 - Fix ``get_next``/``get_prev`` raising ``CroniterBadDateError`` when day-of-month and day-of-week are both restricted and the day-of-month can never occur in the selected month (e.g. ``0 0 31 2 0``). Under the Vixie OR semantics the unsatisfiable side now contributes no dates instead of aborting the whole expression, and ``match()`` and ``croniter_range()``, which swallow the error, no longer return silently wrong results for these expressions. [b245ab6, #243, @semx, @MildlyMeticulous]
+- Fix hashed divisions (``H/{divisor}``, ``H({begin}-{end})/{divisor}``) when the divisor
+  is as wide as, or wider than, the range it is drawn from. Three symptoms, one cause:
+  the offset was drawn from the first period without regard for where the range ends,
+  and the result was emitted as ``{offset}-{end}/{divisor}`` even when the step could
+  not reach a second value. ``H/60`` lost minute 59 and fired at minute 0 twice as
+  often as any other minute (59 distinct schedules over 20,000 hash ids, not 60);
+  ``H(50-59)/10`` fired six times an hour instead of once for the ids hashing to 59;
+  ``H(50-52)/10`` fired outside its own range for 7 hash buckets in 10, and ``H/100``
+  raised ``CroniterBadCronError`` for roughly a third of hash ids. The offset is now
+  clamped to the declared range and emitted as a single value when the step cannot
+  reach a second one. Divisors that fit their range keep their existing hashes, so no
+  schedule that was already correct moves. [#253, @potiuk]
 
 Packaging
 ~~~~~~~~~

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1471,6 +1471,28 @@ class HashExpander:
     def match(self, efl, idx, expr, hash_id=None, **kw):
         return hash_expression_re.match(expr)
 
+    def _expand_divisor(self, idx, m, hash_id, range_begin, range_end):
+        """Hash a start offset into the first period, then step to range_end.
+
+        The offset is drawn from the first period, [range_begin, range_begin +
+        divisor - 1], but never past range_end: a divisor wider than the range has
+        only the range itself to draw from. And when the offset lands on range_end
+        the step cannot reach a second value, so the result is that single value --
+        emitting "{end}-{end}/{divisor}" instead would read as an explicit equal
+        range, which croniter expands to the whole field.
+        """
+        divisor = int(m["divisor"])
+        x = self.do(
+            idx,
+            hash_type=m["hash_type"],
+            hash_id=hash_id,
+            range_begin=range_begin,
+            range_end=min(range_begin + divisor - 1, range_end),
+        )
+        if x == range_end:
+            return str(x)
+        return f"{x}-{range_end}/{divisor}"
+
     def expand(self, efl, idx, expr, hash_id=None, match="", **kw):
         """Expand a hashed/random expression to its normal representation"""
         if match == "":
@@ -1491,14 +1513,9 @@ class HashExpander:
             if int(m["divisor"]) == 0:
                 raise CroniterBadCronError(f"Bad expression: {expr}")
 
-            x = self.do(
-                idx,
-                hash_type=m["hash_type"],
-                hash_id=hash_id,
-                range_begin=int(m["range_begin"]),
-                range_end=int(m["divisor"]) - 1 + int(m["range_begin"]),
+            return self._expand_divisor(
+                idx, m, hash_id, int(m["range_begin"]), int(m["range_end"])
             )
-            return f"{x}-{int(m['range_end'])}/{int(m['divisor'])}"
         if m["range_begin"] and m["range_end"]:
             # Example: H(0-29) -> 12
             return str(
@@ -1515,14 +1532,9 @@ class HashExpander:
             if int(m["divisor"]) == 0:
                 raise CroniterBadCronError(f"Bad expression: {expr}")
 
-            x = self.do(
-                idx,
-                hash_type=m["hash_type"],
-                hash_id=hash_id,
-                range_begin=self.cron.RANGES[idx][0],
-                range_end=int(m["divisor"]) - 1 + self.cron.RANGES[idx][0],
+            return self._expand_divisor(
+                idx, m, hash_id, self.cron.RANGES[idx][0], self.cron.RANGES[idx][1]
             )
-            return f"{x}-{self.cron.RANGES[idx][1]}/{int(m['divisor'])}"
 
         # Example: H -> 32
         return str(self.do(idx, hash_type=m["hash_type"], hash_id=hash_id))

--- a/src/croniter/tests/test_croniter_hash.py
+++ b/src/croniter/tests/test_croniter_hash.py
@@ -155,6 +155,49 @@ class CroniterHashTest(CroniterHashBase):
         self.assertEqual(sorted({e[0] for e in expansions}), list(range(60)))
         self.assertEqual({len(e) for e in expansions}, {1})
 
+    def test_hash_division_invariants(self):
+        """Property sweep over every field with a divisor at least as wide as it.
+
+        Three properties, each of which one of the bugs above broke: a wide divisor
+        yields exactly one value per hash id; that value lies inside the field; and
+        across enough ids every value in the field is reachable. "H/60" satisfied the
+        first two but only reached 59 of the 60 minutes.
+        """
+        for expr, pos, lo, hi in [
+            ("H/60 * * * *", 0, 0, 59),
+            ("* H/24 * * *", 1, 0, 23),
+            ("* * H/31 * *", 2, 1, 31),
+            ("* * * H/12 *", 3, 1, 12),
+            ("* * * * H/7", 4, 0, 6),
+            ("* * * * * H/60", 5, 0, 59),
+            ("0 0 1 1 * 0 H/130", 6, 1970, 2099),
+        ]:
+            with self.subTest(expr=expr):
+                seen = set()
+                for i in range(1200):
+                    got = croniter(expr, hash_id=str(i)).expanded[pos]
+                    self.assertEqual(len(got), 1, f"id={i} expanded to {got}")
+                    self.assertTrue(lo <= got[0] <= hi, f"id={i} produced {got[0]}")
+                    seen.add(got[0])
+                self.assertEqual(sorted(seen), list(range(lo, hi + 1)))
+
+    def test_hash_range_division_never_escapes_its_range(self):
+        """A divisor wider than its range must still land inside the range.
+
+        The offset was drawn from the first period regardless of where the range
+        ends, so "H(50-52)/10" drew from 50-59 and fired outside 50-52 for most
+        hash ids.
+        """
+        for begin, end, divisor in [(50, 52, 10), (5, 6, 30), (1, 3, 60), (10, 11, 2), (0, 1, 59)]:
+            expr = f"H({begin}-{end})/{divisor} * * * *"
+            with self.subTest(expr=expr):
+                seen = set()
+                for i in range(300):
+                    for value in croniter(expr, hash_id=str(i)).expanded[0]:
+                        self.assertTrue(begin <= value <= end, f"id={i} produced {value}")
+                        seen.add(value)
+                self.assertEqual(sorted(seen), list(range(begin, end + 1)))
+
     def test_hash_invalid_range(self):
         """Test validation logic for range_begin and range_end values"""
         try:

--- a/src/croniter/tests/test_croniter_hash.py
+++ b/src/croniter/tests/test_croniter_hash.py
@@ -106,6 +106,55 @@ class CroniterHashTest(CroniterHashBase):
         """Test a hashed range + division definition"""
         self._test_iter("H(30-59)/10 H * * *", datetime(2020, 1, 1, 11, 30), timedelta(minutes=10))
 
+    def test_hash_division_unchanged_when_divisor_fits(self):
+        """Test that a divisor smaller than its range keeps its existing hash"""
+        self.assertEqual(croniter("H/15 * * * *", hash_id="2").expanded[0], [7, 22, 37, 52])
+        self.assertEqual(
+            croniter("H(30-59)/10 * * * *", hash_id="hello").expanded[0], [30, 40, 50]
+        )
+
+    def test_hash_division_offset_at_field_max(self):
+        """Test a division whose hashed offset lands on the field maximum
+
+        "H/60" is one hashed minute an hour, but the offset used to be emitted as
+        "59-59/60" -- an explicit equal range, which croniter reads as the whole
+        field. Minute 59 was lost and minute 0 came up twice as often as any other.
+        """
+        self.assertEqual(croniter("H/60 * * * *", hash_id="79").expanded[0], [59])
+        expansions = [croniter("H/60 * * * *", hash_id=str(i)).expanded[0] for i in range(300)]
+        self.assertEqual(sorted({e[0] for e in expansions}), list(range(60)))
+        self.assertEqual({len(e) for e in expansions}, {1})
+
+    def test_hash_range_division_offset_at_range_end(self):
+        """Test a hashed range + division whose offset lands on the range end"""
+        self.assertEqual(croniter("H(50-59)/10 * * * *", hash_id="0").expanded[0], [59])
+        expansions = [
+            croniter("H(50-59)/10 * * * *", hash_id=str(i)).expanded[0] for i in range(300)
+        ]
+        self.assertEqual(sorted({e[0] for e in expansions}), list(range(50, 60)))
+        self.assertEqual({len(e) for e in expansions}, {1})
+
+    def test_hash_divisor_wider_than_range(self):
+        """Test a divisor wider than the range it is drawn from
+
+        The offset is drawn from the first period, so it used to be able to land
+        outside the range the expression declares.
+        """
+        self.assertEqual(croniter("H(50-52)/10 * * * *", hash_id="0").expanded[0], [52])
+        self.assertEqual(croniter("H(50-52)/10 * * * *", hash_id="hello").expanded[0], [51])
+        expansions = [
+            croniter("H(50-52)/10 * * * *", hash_id=str(i)).expanded[0] for i in range(300)
+        ]
+        self.assertEqual(sorted({e[0] for e in expansions}), [50, 51, 52])
+        self.assertEqual({len(e) for e in expansions}, {1})
+
+    def test_hash_divisor_wider_than_field(self):
+        """Test a divisor wider than the field, which used to fail for some hashes"""
+        self.assertEqual(croniter("H/100 * * * *", hash_id="79").expanded[0], [59])
+        expansions = [croniter("H/100 * * * *", hash_id=str(i)).expanded[0] for i in range(300)]
+        self.assertEqual(sorted({e[0] for e in expansions}), list(range(60)))
+        self.assertEqual({len(e) for e in expansions}, {1})
+
     def test_hash_invalid_range(self):
         """Test validation logic for range_begin and range_end values"""
         try:


### PR DESCRIPTION
`HashExpander` draws an offset from the first period and emits `{offset}-{end}/{divisor}`. Neither half accounts for a divisor as wide as the range it is drawn from, which gives several symptoms from one cause:

| expression | before | after |
|---|---|---|
| `H/60 * * * *` | 59 distinct schedules over 20,000 hash ids, not 60; minute 0 fires twice as often as any other, because the ids hashing to 59 emit `59-59/60` — an explicit equal range, which croniter expands to the whole field | 60 distinct, uniform |
| `H(50-59)/10 * * * *` | six fires an hour instead of one, for the ~10% of ids hashing to 59 | one fire |
| `H(50-52)/10 * * * *` | fires **outside** the declared range for 7 hash buckets in 10 — `[8,18,28,38,48,57]` and similar — since the offset is drawn from `[50,59]` regardless of where the range ends | 3 buckets, all within `50-52` |
| `H/100 * * * *` | `CroniterBadCronError` for roughly a third of hash ids | works |

The offset is now clamped to the declared range, and emitted as a single value when the step cannot reach a second one.

**Divisors that fit their range keep their existing hashes** — `H/15` and `H(30-59)/10` are unchanged — so no schedule that was already correct moves. Only shapes where the divisor is as wide as or wider than its range are affected, and those were producing one of the four defects above.

Found while reviewing #246, which fixes the same "equal range means the whole field" collision on the non-hashed side. Independent of it: the two touch different code and neither needs the other.
