### PR TITLE
Fix expand_from_start_time raising ValueError in the seconds and years fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,21 @@ Bugfixes
   UTC round-trips it to the same wall clock and naive callers see no change at all —
   verified over 45,312 expansions with naive start times, none of which differ.
   [#256, @potiuk]
+- Fix ``expand_from_start_time`` raising ``ValueError: Can't get current date number for
+  index larger than 4`` for any range or step in the optional **seconds** or **years**
+  field. ``croniter("* * * * * */15", start, expand_from_start_time=True)`` aborted, and
+  because the exception came from outside the ``CroniterError`` hierarchy, code catching
+  ``CroniterError`` never saw it. Both fields now re-base like the five that already
+  worked: seconds take their phase from the start time's second, and years — which do
+  not start at zero — take theirs from the field minimum, as day-of-month and month
+  already do. [#254, @potiuk]
+
+  Note that ``_get_low_from_current_date_number`` reads the start time in UTC, so for a
+  timezone-aware ``start_time`` the phase is taken from the UTC hour, day, month and now
+  year rather than the local one. That is pre-existing — ``0 */5 * * *`` already phases
+  on the UTC hour — and is not addressed here, but the year field is where it is most
+  visible: a start of ``2025-01-01 05:00+13:00`` is ``2024`` in UTC, so the year phase
+  is a whole year off.
 
 Packaging
 ~~~~~~~~~

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1319,8 +1319,15 @@ class croniter:
             return ((dt.month - 1) % step) + 1
         if field_index == DOW_FIELD:
             return (dt.isoweekday() % 7) % step
+        if field_index == SECOND_FIELD:
+            return dt.second % step
+        if field_index == YEAR_FIELD:
+            # Like day and month, the year field does not start at 0, so the phase is
+            # taken from the field minimum rather than from the value itself.
+            year_start = cls.RANGES[YEAR_FIELD][0]
+            return ((dt.year - year_start) % step) + year_start
 
-        raise ValueError("Can't get current date number for index larger than 4")
+        raise ValueError(f"Can't get current date number for field index {field_index}")
 
     @classmethod
     def is_valid(cls, expression, hash_id=None, encoding="UTF-8", second_at_beginning=False, strict=False, strict_year=None):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2600,6 +2600,7 @@ class CroniterTest(base.TestCase):
                         local = getattr(start, attribute)
                         lo = croniter.RANGES[field][0]
                         self.assertIn(((local - lo) % 5) + lo, got)
+
     def test_expand_from_start_time_second(self):
         fifteen_seconds_interval_pattern = "* * * * * */15"
         ret1 = croniter(
@@ -2672,6 +2673,44 @@ class CroniterTest(base.TestCase):
         for expr in ("* * * * * */15", "* * * * * 10-20", "0 0 1 1 * 0 */25"):
             with self.subTest(expr=expr):
                 croniter(expr, start_time=start, expand_from_start_time=True).get_next(datetime)
+
+    def test_expand_from_start_time_seconds_and_years_invariants(self):
+        """Property sweep: no step in these fields may raise or leave its range.
+
+        Every one of these raised the bare ValueError before, whatever the step.
+        """
+        start = datetime(2024, 7, 11, 10, 7, 23)
+        for step in (1, 2, 3, 7, 15, 60, 131):
+            for expr, field, lo, hi in (
+                (f"* * * * * */{step}", 5, 0, 59),
+                (f"0 0 1 1 * 0 */{step}", 6, 1970, 2099),
+            ):
+                with self.subTest(expr=expr):
+                    got = croniter(expr, start_time=start, expand_from_start_time=True).expanded[
+                        field
+                    ]
+                    self.assertTrue(got, "expanded to nothing")
+                    if got == ["*"]:
+                        # A step of 1 covers the field, which croniter folds to "*".
+                        self.assertEqual(step, 1)
+                        continue
+                    for value in got:
+                        self.assertTrue(lo <= value <= hi, f"{value} outside [{lo}, {hi}]")
+
+    def test_expand_from_start_time_seconds_phase_matches_minutes(self):
+        """Seconds must re-base by the same rule minutes already use."""
+        for second in range(0, 60, 7):
+            with self.subTest(second=second):
+                start = datetime(2024, 7, 11, 10, 7, second)
+                seconds = croniter(
+                    "* * * * * */15", start_time=start, expand_from_start_time=True
+                ).expanded[5]
+                minutes = croniter(
+                    "*/15 * * * *",
+                    start_time=start.replace(minute=second),
+                    expand_from_start_time=True,
+                ).expanded[0]
+                self.assertEqual(seconds, minutes)
 
     def test_get_next_fails_with_expand_from_start_time_true(self):
         expanded_croniter = croniter("0 0 */5 * *", expand_from_start_time=True)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2600,6 +2600,78 @@ class CroniterTest(base.TestCase):
                         local = getattr(start, attribute)
                         lo = croniter.RANGES[field][0]
                         self.assertIn(((local - lo) % 5) + lo, got)
+    def test_expand_from_start_time_second(self):
+        fifteen_seconds_interval_pattern = "* * * * * */15"
+        ret1 = croniter(
+            fifteen_seconds_interval_pattern,
+            start_time=datetime(2024, 7, 11, 10, 7, 23),
+            expand_from_start_time=True,
+        ).get_next(datetime)
+        self.assertEqual(ret1, datetime(2024, 7, 11, 10, 7, 38))
+
+        ret2 = croniter(
+            fifteen_seconds_interval_pattern,
+            start_time=datetime(2024, 7, 11, 10, 7, 24),
+            expand_from_start_time=True,
+        ).get_next(datetime)
+        self.assertEqual(ret2, datetime(2024, 7, 11, 10, 7, 39))
+
+        ret3 = croniter(
+            fifteen_seconds_interval_pattern,
+            start_time=datetime(2024, 7, 11, 10, 7, 23),
+            expand_from_start_time=True,
+        ).get_prev(datetime)
+        self.assertEqual(ret3, datetime(2024, 7, 11, 10, 7, 8))
+
+        # Seconds take their phase from the start time's second, exactly as minutes
+        # take theirs from its minute.
+        self.assertEqual(
+            croniter(
+                fifteen_seconds_interval_pattern,
+                start_time=datetime(2024, 7, 11, 10, 7, 23),
+                expand_from_start_time=True,
+            ).expanded[5],
+            [8, 23, 38, 53],
+        )
+
+    def test_expand_from_start_time_year(self):
+        every_25_years_pattern = "0 0 1 1 * 0 */25"
+        ret1 = croniter(
+            every_25_years_pattern,
+            start_time=datetime(2024, 7, 11),
+            expand_from_start_time=True,
+        ).get_next(datetime)
+        self.assertEqual(ret1, datetime(2049, 1, 1))
+
+        ret2 = croniter(
+            every_25_years_pattern,
+            start_time=datetime(2024, 7, 11),
+            expand_from_start_time=True,
+        ).get_prev(datetime)
+        self.assertEqual(ret2, datetime(2024, 1, 1))
+
+        # The year field does not start at zero, so its phase is taken from the field
+        # minimum, as day-of-month and month already do.
+        self.assertEqual(
+            croniter(
+                every_25_years_pattern,
+                start_time=datetime(2024, 7, 11),
+                expand_from_start_time=True,
+            ).expanded[6],
+            [1974, 1999, 2024, 2049, 2074, 2099],
+        )
+
+    def test_expand_from_start_time_second_and_year_no_longer_raise(self):
+        """Both fields used to raise a bare ValueError, outside CroniterError.
+
+        _get_low_from_current_date_number only handled field indices 0-4, so any
+        range or step in the seconds or years field aborted with a ValueError that
+        code catching CroniterError never saw.
+        """
+        start = datetime(2024, 7, 11, 10, 7, 23)
+        for expr in ("* * * * * */15", "* * * * * 10-20", "0 0 1 1 * 0 */25"):
+            with self.subTest(expr=expr):
+                croniter(expr, start_time=start, expand_from_start_time=True).get_next(datetime)
 
     def test_get_next_fails_with_expand_from_start_time_true(self):
         expanded_croniter = croniter("0 0 */5 * *", expand_from_start_time=True)


### PR DESCRIPTION
`_get_low_from_current_date_number` only handles field indices 0-4, so **any** range or step in the optional seconds or years field aborts the expansion:

```python
croniter("* * * * * */15", start, expand_from_start_time=True)
# ValueError: Can't get current date number for index larger than 4
```

Not only at the field maximum and not only for steps — `* * * * * 10-20` fails too. `expand_from_start_time` is effectively unusable with any 6- or 7-field expression that contains a range in those fields.

The exception is also raised from outside the `CroniterError` hierarchy, so code catching `CroniterError` never sees it.

Both fields now re-base like the five that already worked: seconds take their phase from the start time's second, and years — which do not start at zero — take theirs from the field minimum, as day-of-month and month already do.

Since every affected expression raised before, nothing that previously returned a result changes.

Noted in passing in #246's release notes as pre-existing; this is that fix.

**Ordering note.** Until #255 lands, a plain range in these fields will behave like a plain range in the minute field does today — `* * * * * 10-20` expands from second 0 rather than second 10 — because `expand_from_start_time` discards explicit lower bounds in every field. That is the same bug everywhere, and that PR fixes it everywhere; only the final 6.2.5 state matters to users.
