### PR TITLE
Make expand_from_start_time supply the phase of a cycle, not its bounds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,9 +46,11 @@ Bugfixes
   normalizes to ``{start}-{max}/{step}``; when ``start`` is the maximum the two
   bounds collide, making the token indistinguishable from an explicitly written
   equal range such as ``Jan-Jan``, which croniter deliberately expands to the whole
-  cycle. The two forms are now distinguished. An explicitly written equal range is
-  unchanged, and so is every start below the field maximum. The fix applies in
-  ``expand_from_start_time`` mode as well as by default. [#246, @earfman]
+  cycle. The two forms are now distinguished. An explicitly written equal range still
+  means the whole cycle, and every start below the field maximum is unchanged. The fix
+  applies in ``expand_from_start_time`` mode as well as by default. (Under that flag
+  the whole cycle an equal range names now takes its phase from ``start_time``, as
+  every other cycle does — see #255 below.) [#246, @earfman]
 
   .. warning::
 
@@ -74,12 +76,14 @@ Bugfixes
   overwrote ``low`` outright instead of supplying the phase of the cycle, so any range
   whose start was above the field minimum fired below its own start: ``* 8-17 * * *``
   expanded to hours ``0-17``, ``* * * * MON-FRI`` included Sunday, and ``10-50/15``
-  expanded to minutes ``7,22,37`` from a start at minute ``7``. Over a sweep of 13,332
-  ``expand_from_start_time`` expansions, 10,571 contained at least one value outside
-  the range the expression declares; now none do. Re-basing still supplies the phase —
-  ``*/15`` and ``5/15`` are unchanged — but the phase is advanced to the first value
-  inside the declared range, and where no value of the phase fits, the expression is
-  honoured as written, so an expansion can never come out empty. [#255, @potiuk]
+  expanded to minutes ``7,22,37`` from a start at minute ``7``. Over a sweep of 101,088
+  ``expand_from_start_time`` expansions — all seven fields, every legal lower bound,
+  eight token shapes, seven steps, four start times — 73,898 contained at least one
+  value outside the range the expression declares; now none do. Re-basing still
+  supplies the phase — ``*/15`` and ``5/15`` are unchanged — but the phase is advanced
+  to the first value inside the declared range, and where no value of the phase fits,
+  the expression is honoured as written, so an expansion can never come out empty.
+  [#255, @potiuk]
 
   Two side effects of overwriting the bound are fixed with it: colliding ``low`` onto
   ``high`` made an ordinary range read as an explicit equal range and expand to the
@@ -87,25 +91,45 @@ Bugfixes
   a wrapping range unwrapped it (``* * * * 6-0``, Saturday and Sunday, became every day
   of the week).
 
+  An explicitly written equal range means the whole cycle, and that cycle now takes its
+  phase from ``start_time`` like any other, so the two spellings of one schedule agree:
+  ``1-1/3`` and ``*/3`` in the month field both expand to February, May, August and
+  November from a start in February. Under the old behaviour they agreed by accident —
+  the discarded bound happened to land on the phase — and pinning the bound without
+  this would have made ``1-1/3`` ignore the flag outright, contradicting what the
+  README documents for it.
+
+  Also fixed, on the same line: a ``start_time`` of exactly the Unix epoch skipped
+  re-basing altogether, because the start time reaches the expansion as a timestamp
+  and ``0.0`` is falsy. ``0 0 * * 2-6/3`` from ``1970-01-01`` expanded to days ``2,5``
+  where the same expression one second later expanded to day ``4``.
+
   .. warning::
 
-     **This changes most ``expand_from_start_time`` schedules.** 12,062 of the 13,332
-     expansions in the sweep differ; those that do not are the wildcard forms (``*``,
-     ``*/step``), which were already correct. Any explicitly written range or stepped
-     start is affected, and a schedule can fire less often than it used to — ``45/15``
-     goes from four fires an hour to one, which is what that expression already means
-     without the flag. No expansion gains a value: 10,089 of the differences are strict
-     subsets of what they replaced, and in all but three of the remaining 1,973 the old
-     expansion contained values the declared range never allowed. The three are the
-     month field with a step wider than the field, where the phase moves from January
-     to the correct month. No expansion became empty and no error status changed.
+     **This changes most ``expand_from_start_time`` schedules.** 93,456 of the 101,088
+     expansions in the sweep differ. Any explicitly written range, equal range, wrapping
+     range or stepped start is affected; the untouched shapes are the plain wildcard,
+     the bare value, and ``*/step`` except where the step is wide enough to collide the
+     field's own bounds (``*/60`` in the minute field re-based to minute ``0`` rather
+     than to its phase). Default-mode expansions do not move at all, no expansion became
+     empty, and no error status changed.
 
-     A re-phased range can also hold fewer periods than the one it replaces, even when
-     nothing was wrong with it: ``10-20/7`` is ``10,17`` by default but ``14`` alone
-     from a start at minute 7, because only one multiple of 7 in that phase falls
-     inside ``10-20``. That is inherent to re-phasing a step inside a bounded window.
-     Over 29,280 bounded-range cases the fire count drops in 8,691, never by more than
-     one period, and never to zero.
+     **A schedule can fire less often than it did.** ``45/15`` goes from four fires an
+     hour to one, which is what that expression already means without the flag. More
+     generally, re-phasing a step inside a fixed window can cost one period even when
+     nothing was wrong with the schedule: ``10-20/7`` is ``10,17`` by default but ``14``
+     alone from a start at minute 7. Measured against the default expansion of the same
+     expression, no re-based expansion in the sweep fires *more* often, 13,539 fire
+     less, and the drop is never more than one period and never to zero.
+
+     **A schedule can also fire more often than it did**, in 17,038 of the swept
+     expansions. Every one of them is an explicit equal range or a wrapping range —
+     the two shapes the old behaviour re-read as something else. ``1-1/15`` in the
+     minute field expanded to ``[0]`` from a start at minute 0 and is now ``[0, 15, 30,
+     45]``, the whole cycle the equal range asks for; the wrapping range ``2-1``, which
+     covers the whole minute field, expanded to minutes ``0,1`` and is now every minute.
+     These are meanings being restored, not values being invented: no expansion holds a
+     value the expression does not declare.
 
 Testing and Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,6 +139,10 @@ Testing and Documentation
   timezone. Also document that a range with two equal bounds (``Jan-Jan``, ``Sun-Sun``)
   means the whole cycle rather than the value it names, which was undocumented and is
   the rule behind several of the bugs fixed in this release. [#257, @potiuk]
+- Document the bounds half of ``expand_from_start_time``: that a field declaring its own
+  range keeps both bounds and only the phase moves, that moving a phase inside a fixed
+  window can cost one period, that an expression whose phase does not fit is honoured as
+  written, and that a wrapping range is left alone. [#255, @potiuk]
 
 Packaging
 ~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,43 @@ Bugfixes
      happens without a year field wherever the remaining value cannot occur:
      ``0 0 31/5 2 *`` is now day 31 of February.
 
+- Fix ``expand_from_start_time`` discarding the lower bound of every range. Re-basing
+  overwrote ``low`` outright instead of supplying the phase of the cycle, so any range
+  whose start was above the field minimum fired below its own start: ``* 8-17 * * *``
+  expanded to hours ``0-17``, ``* * * * MON-FRI`` included Sunday, and ``10-50/15``
+  expanded to minutes ``7,22,37`` from a start at minute ``7``. Over a sweep of 13,332
+  ``expand_from_start_time`` expansions, 10,571 contained at least one value outside
+  the range the expression declares; now none do. Re-basing still supplies the phase —
+  ``*/15`` and ``5/15`` are unchanged — but the phase is advanced to the first value
+  inside the declared range, and where no value of the phase fits, the expression is
+  honoured as written, so an expansion can never come out empty. [#255, @potiuk]
+
+  Two side effects of overwriting the bound are fixed with it: colliding ``low`` onto
+  ``high`` made an ordinary range read as an explicit equal range and expand to the
+  whole cycle (``* * 10-11/2 * *`` became every second day of the month), and re-basing
+  a wrapping range unwrapped it (``* * * * 6-0``, Saturday and Sunday, became every day
+  of the week).
+
+  .. warning::
+
+     **This changes most ``expand_from_start_time`` schedules.** 12,062 of the 13,332
+     expansions in the sweep differ; those that do not are the wildcard forms (``*``,
+     ``*/step``), which were already correct. Any explicitly written range or stepped
+     start is affected, and a schedule can fire less often than it used to — ``45/15``
+     goes from four fires an hour to one, which is what that expression already means
+     without the flag. No expansion gains a value: 10,089 of the differences are strict
+     subsets of what they replaced, and in all but three of the remaining 1,973 the old
+     expansion contained values the declared range never allowed. The three are the
+     month field with a step wider than the field, where the phase moves from January
+     to the correct month. No expansion became empty and no error status changed.
+
+     A re-phased range can also hold fewer periods than the one it replaces, even when
+     nothing was wrong with it: ``10-20/7`` is ``10,17`` by default but ``14`` alone
+     from a start at minute 7, because only one multiple of 7 in that phase falls
+     inside ``10-20``. That is inherent to re-phasing a step inside a bounded window.
+     Over 29,280 bounded-range cases the fire count drops in 8,691, never by more than
+     one period, and never to zero.
+
 Testing and Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 - Document what ``expand_from_start_time`` actually means — that it moves the phase of a

--- a/README.rst
+++ b/README.rst
@@ -308,6 +308,31 @@ take their phase from the start time's second. Day-of-month, month and year do
 not start at zero, so they take theirs from the field minimum rather than from
 the value itself.
 
+**Only the phase moves.** A field that declares its own range keeps both of its
+bounds, and the phase is moved *into* that range::
+
+    >>> croniter('10-50/15 * * * *', datetime(2024, 7, 11, 10, 7), expand_from_start_time=True).expanded[0]
+    [22, 37]
+    >>> croniter('10-50/15 * * * *', datetime(2024, 7, 11, 10, 7)).expanded[0]
+    [10, 25, 40]
+
+Three consequences of moving a phase inside a fixed window are worth stating.
+A re-based range can hold one period fewer than the default expansion does —
+``10-20/7`` is ``10,17`` by default and ``14`` alone from a start at minute 7.
+Where no value of the phase falls inside the range at all, the expression is
+honoured as written, so an expansion is never empty. And a range whose bounds
+wrap — ``6-0`` in day-of-week, Saturday and Sunday — has no single in-range
+phase, so it too is left as written.
+
+An equal range means the whole cycle (see `Note about Ranges`_), and that cycle
+takes its phase from ``start_time`` like any other, so the two spellings of one
+schedule agree::
+
+    >>> croniter('0 0 1 1-1/3 *', datetime(2024, 2, 15), expand_from_start_time=True).expanded[3]
+    [2, 5, 8, 11]
+    >>> croniter('0 0 1 */3 *', datetime(2024, 2, 15), expand_from_start_time=True).expanded[3]
+    [2, 5, 8, 11]
+
 The phase is read from ``start_time`` in **its own timezone**, so a
 timezone-aware start time phases on the local wall clock, not on its UTC form::
 
@@ -483,7 +508,9 @@ cycle**, not the single value it names. This applies in every field::
 
 So ``Jan-Jan`` is every month, not January. A step is applied across that whole
 cycle, so ``1-1/3`` in the month field is January, April, July and October. To
-name a single value, write it on its own — ``1`` or ``JAN``.
+name a single value, write it on its own — ``1`` or ``JAN``. Under
+``expand_from_start_time`` that cycle takes its phase from the start time, like
+the ``*/3`` spelling of the same schedule.
 
 Note about Sunday
 =================

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1129,14 +1129,36 @@ class croniter:
                     # should mean under that flag, and it is not this fix's to answer.
                     start_at_field_max = start_with_step and low == high
 
+                    # Only an equal range that was *written* as one means the whole
+                    # cycle. Both the "{start}/{step}" normalization above and the
+                    # re-basing below can collide the two bounds as a side effect, and
+                    # neither is the user saying "Jan-Jan".
+                    explicit_equal_range = low == high and not start_with_step
+
                     # ``from_timestamp`` re-bases the start of a *cycle* on the start
                     # time. A single point has no cycle to re-base, and rewriting its
                     # bound here would leave the bug reachable in
                     # ``expand_from_start_time`` mode while looking fixed by default.
-                    if from_timestamp and not start_at_field_max:
-                        low = cls._get_low_from_current_date_number(
+                    if from_timestamp and not start_at_field_max and low <= high:
+                        # Re-basing supplies the *phase* of the cycle, not its bounds:
+                        # take the first value of that phase lying inside the range the
+                        # expression declares. From a start at minute 7, "10-50/15" is
+                        # 22,37 -- not 7,22,37, which fires below its own lower bound.
+                        # If no value of the phase fits, the expression is honoured as
+                        # written, so an expansion can never come out empty. Note that
+                        # a re-phased range can hold fewer periods than the one it
+                        # replaces -- "10-20/7" is 10,17 by default but 14 alone from
+                        # a start at minute 7 -- which is inherent to re-phasing inside
+                        # a bounded window, not a value being dropped. A wrapping range
+                        # (Apr-Jan, Sat-Sun) has no single in-range phase to pick, so it
+                        # is left alone rather than silently unwrapped.
+                        phase = cls._get_low_from_current_date_number(
                             field_index, int(step), int(from_timestamp), from_timestamp_tz
                         )
+                        if phase < low:
+                            phase += -(-(low - phase) // step) * step
+                        if low <= phase <= high:
+                            low = phase
 
                     # Handle when the second bound of the range is in backtracking order:
                     # eg: X-Sun or X-7 (Sat-Sun) in DOW, or X-Jan (Apr-Jan) in MONTH
@@ -1161,7 +1183,7 @@ class croniter:
                         rng += list(range(cls.RANGES[field_index][0] + to_skip, high + 1, step))
                     # if we include a range type: Jan-Jan, or Sun-Sun,
                     #  it means the whole cycle (all days of week, # all monthes of year, etc)
-                    elif low == high:
+                    elif explicit_equal_range:
                         rng = list(
                             range(cls.RANGES[field_index][0], cls.RANGES[field_index][1] + 1, step)
                         )

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1115,31 +1115,39 @@ class croniter:
                     # "{start}/{step}" normalizes to "{start}-{max}/{step}", so when
                     # the start IS the field maximum the two bounds collide and the
                     # token becomes indistinguishable from an explicitly written equal
-                    # range. That is the whole bug: "59/15" arrived at the ``low ==
-                    # high`` branch below -- which exists for "Jan-Jan" and expands to
-                    # the whole cycle -- and so fired at :00/:15/:30/:45 instead of
-                    # :59. Recognising the collision here is what keeps the two apart.
+                    # range. That is the whole bug: "59/15" was read the way "Jan-Jan"
+                    # is -- the whole cycle -- and so fired at :00/:15/:30/:45 instead
+                    # of :59. Recognising the collision here is what keeps the two
+                    # apart, both in the widening just below and in the range built
+                    # further down.
                     #
                     # Deliberately ``low == high`` and not the wider ``low + step >
-                    # high``. Both fix the reported bug, but the wider form also
-                    # suppresses the re-base below for starts that are not at the
-                    # maximum, silently changing ~365 additional
-                    # ``expand_from_start_time`` schedules that were never broken.
-                    # That is a separate question about what an explicit lower bound
-                    # should mean under that flag, and it is not this fix's to answer.
+                    # high``. Only the collision is a false equal range: a token whose
+                    # step merely overshoots its range -- "50-51/15" -- still describes
+                    # a cycle, and re-basing must stay free to supply its phase.
                     start_at_field_max = start_with_step and low == high
 
-                    # Only an equal range that was *written* as one means the whole
-                    # cycle. Both the "{start}/{step}" normalization above and the
-                    # re-basing below can collide the two bounds as a side effect, and
-                    # neither is the user saying "Jan-Jan".
-                    explicit_equal_range = low == high and not start_with_step
+                    # An equal range that was *written* as one -- "Jan-Jan", "Sun-Sun"
+                    # -- means the whole cycle, so widen it to the field's own bounds
+                    # here rather than in a branch further down. Widening it before
+                    # re-basing is what makes the two spellings of one schedule agree:
+                    # "1-1/3" and "*/3" are the same expression, and both now take the
+                    # phase of their cycle from ``start_time``.
+                    #
+                    # ``start_with_step`` is load-bearing: "{start}/{step}" normalizes
+                    # to "{start}-{max}/{step}", so at the field maximum its bounds
+                    # collide without the user having written an equal range at all.
+                    # That is #246's bug, and widening "59/15" back to the whole field
+                    # here would reintroduce it.
+                    if low == high and not start_with_step:
+                        low, high = cls.RANGES[field_index]
 
                     # ``from_timestamp`` re-bases the start of a *cycle* on the start
-                    # time. A single point has no cycle to re-base, and rewriting its
-                    # bound here would leave the bug reachable in
-                    # ``expand_from_start_time`` mode while looking fixed by default.
-                    if from_timestamp and not start_at_field_max and low <= high:
+                    # time. A single point has no cycle to re-base: "59/15" is minute
+                    # 59, not a cycle starting there. (The bounds test below rejects it
+                    # anyway, since the only phase inside ``low == high`` is ``low``
+                    # itself; skipping the work here says so outright.)
+                    if from_timestamp is not None and not start_at_field_max:
                         # Re-basing supplies the *phase* of the cycle, not its bounds:
                         # take the first value of that phase lying inside the range the
                         # expression declares. From a start at minute 7, "10-50/15" is
@@ -1149,14 +1157,18 @@ class croniter:
                         # a re-phased range can hold fewer periods than the one it
                         # replaces -- "10-20/7" is 10,17 by default but 14 alone from
                         # a start at minute 7 -- which is inherent to re-phasing inside
-                        # a bounded window, not a value being dropped. A wrapping range
-                        # (Apr-Jan, Sat-Sun) has no single in-range phase to pick, so it
-                        # is left alone rather than silently unwrapped.
+                        # a bounded window, not a value being dropped.
                         phase = cls._get_low_from_current_date_number(
                             field_index, int(step), int(from_timestamp), from_timestamp_tz
                         )
                         if phase < low:
                             phase += -(-(low - phase) // step) * step
+                        # This one test is what keeps re-basing honest, and it covers
+                        # the wrapping ranges (Apr-Jan, Sat-Sun) too: there ``high``
+                        # lies below ``low``, no phase can satisfy it, and the range is
+                        # left as written rather than silently unwrapped. Its lower
+                        # half restates what the advance above already guarantees; it
+                        # is written out so the test reads as the range check it is.
                         if low <= phase <= high:
                             low = phase
 
@@ -1181,12 +1193,6 @@ class croniter:
                             ):
                                 to_skip = step - already_skipped
                         rng += list(range(cls.RANGES[field_index][0] + to_skip, high + 1, step))
-                    # if we include a range type: Jan-Jan, or Sun-Sun,
-                    #  it means the whole cycle (all days of week, # all monthes of year, etc)
-                    elif explicit_equal_range:
-                        rng = list(
-                            range(cls.RANGES[field_index][0], cls.RANGES[field_index][1] + 1, step)
-                        )
                     else:
                         try:
                             rng = list(range(low, high + 1, step))

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -551,13 +551,12 @@ class CroniterTest(base.TestCase):
         # hierarchy, so nothing catching CroniterError ever saw it. That fix made
         # the field reachable; this pins the value it reaches.
         self.assertEqual(efst("* * * * * 59/15", 5), [59])
-        # Re-basing is untouched for every token that really does describe a cycle,
-        # including stepped starts below the maximum. Whether an explicit lower bound
-        # ought to survive re-basing at all is a separate question, deliberately not
-        # answered here: "45/15" keeps its existing behaviour.
+        # Re-basing still supplies the phase for every token that describes a cycle.
+        # Where that phase falls below an explicitly written start it is advanced into
+        # range -- see test_expand_from_start_time_respects_declared_bounds.
         self.assertEqual(efst("*/15 * * * *", m), [7, 22, 37, 52])
         self.assertEqual(efst("5/15 * * * *", m), [7, 22, 37, 52])
-        self.assertEqual(efst("45/15 * * * *", m), [7, 22, 37, 52])
+        self.assertEqual(efst("45/15 * * * *", m), [52])
 
     def test_step_of_one_from_field_max(self):
         """ "{max}/1" is the start alone, where it used to be the whole field.
@@ -2819,6 +2818,75 @@ class CroniterTest(base.TestCase):
                     expand_from_start_time=True,
                 ).expanded[0]
                 self.assertEqual(seconds, minutes)
+
+    def test_expand_from_start_time_respects_declared_bounds(self):
+        """Re-basing supplies the phase of a cycle, never a bound outside the range.
+
+        expand_from_start_time overwrote the lower bound of every range, so an
+        explicitly written range fired below its own start: "* 8-17 * * *" expanded
+        to hours 0-17, and "10-50/15" to minutes 7,22,37 from a start at minute 7.
+        """
+        start = datetime(2024, 7, 11, 10, 7)
+
+        def efst(expr, field):
+            return croniter(expr, start_time=start, expand_from_start_time=True).expanded[field]
+
+        m, h, dow = 0, 1, 4
+        # A plain range keeps both of its bounds.
+        self.assertEqual(efst("10-20 * * * *", m), list(range(10, 21)))
+        self.assertEqual(efst("* 8-17 * * *", h), list(range(8, 18)))
+        self.assertEqual(efst("* * * * 1-5", dow), [1, 2, 3, 4, 5])
+        # A stepped range keeps its phase, advanced into the range.
+        self.assertEqual(efst("10-50/15 * * * *", m), [22, 37])
+        self.assertEqual(
+            croniter("10-50/15 * * * *", start_time=start, expand_from_start_time=True).get_next(
+                datetime
+            ),
+            datetime(2024, 7, 11, 10, 22),
+        )
+        # A wildcard is unaffected: its lower bound is the field minimum already.
+        self.assertEqual(efst("*/15 * * * *", m), [7, 22, 37, 52])
+        self.assertEqual(efst("5/15 * * * *", m), [7, 22, 37, 52])
+        # A start above the phase advances to the next value of the same phase.
+        self.assertEqual(efst("45/15 * * * *", m), [52])
+        # When no value of the phase fits, the expression is honoured as written
+        # rather than losing its only fire.
+        self.assertEqual(efst("50-51/15 * * * *", m), [50])
+        self.assertEqual(efst("59/15 * * * *", m), [59])
+        # A re-phased range can hold fewer periods than the default phase does: only
+        # one multiple of 7 in this phase falls inside 10-20. Inherent to re-phasing a
+        # step inside a bounded window, not a value being dropped -- pinned so the
+        # difference from the default expansion stays deliberate.
+        self.assertEqual(croniter("10-20/7 * * * *", start_time=start).expanded[m], [10, 17])
+        self.assertEqual(efst("10-20/7 * * * *", m), [14])
+
+    def test_expand_from_start_time_does_not_change_a_range_into_another_kind(self):
+        """Re-basing must not collide or unwrap the bounds it re-bases.
+
+        Landing the lower bound on the upper one made an ordinary range read as
+        "Jan-Jan" -- the whole cycle -- and re-basing a wrapping range unwrapped it,
+        so "6-0" (Sat-Sun) became every day of the week.
+        """
+        start = datetime(2024, 7, 11, 10, 7)
+
+        def efst(expr, field):
+            return croniter(expr, start_time=start, expand_from_start_time=True).expanded[field]
+
+        m, dom, mon, dow = 0, 2, 3, 4
+        # An explicitly written equal range still means the whole cycle, as by default.
+        self.assertEqual(efst("5-5 * * * *", m), ["*"])
+        self.assertEqual(efst("59-59/15 * * * *", m), [0, 15, 30, 45])
+        self.assertEqual(efst("* * * 12-12 *", mon), ["*"])
+        # A range whose phase lands on its own upper bound is not an equal range.
+        self.assertEqual(efst("* * 10-11/2 * *", dom), [11])
+        self.assertEqual(
+            croniter(
+                "0 0 1 */15 *", start_time=datetime(2031, 12, 31), expand_from_start_time=True
+            ).expanded[mon],
+            [12],
+        )
+        # A wrapping range stays wrapped.
+        self.assertEqual(efst("* * * * 6-0", dow), [0, 6])
 
     def test_get_next_fails_with_expand_from_start_time_true(self):
         expanded_croniter = croniter("0 0 */5 * *", expand_from_start_time=True)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2880,6 +2880,42 @@ class CroniterTest(base.TestCase):
         self.assertEqual(croniter("10-20/7 * * * *", start_time=start).expanded[m], [10, 17])
         self.assertEqual(efst("10-20/7 * * * *", m), [14])
 
+    def test_expand_from_start_time_respects_declared_bounds_in_seconds_and_years(self):
+        """The optional fields advance the phase like the five that always could.
+
+        #254 is what made the seconds and years fields reachable here at all -- they
+        raised ValueError before it -- and the years field is where the correction is
+        largest: "2020-2040/3" used to expand from 1970, eighteen years below its own
+        lower bound.
+        """
+        seconds, years = 5, 6
+
+        def efst(expr, start, field):
+            return croniter(expr, start_time=start, expand_from_start_time=True).expanded[field]
+
+        start = datetime(2024, 7, 11, 10, 7, 23)
+        # Phase 23 % 15 = 8, below the declared start, so it advances to 23.
+        self.assertEqual(efst("* * * * * 10-50/15", start, seconds), [23, 38])
+        self.assertEqual(croniter("* * * * * 10-50/15", start).expanded[seconds], [10, 25, 40])
+        self.assertEqual(efst("* * * * * 20-40/5", start, seconds), [23, 28, 33, 38])
+        # A second below the range keeps the expression as written rather than firing
+        # early, exactly as in the five mandatory fields.
+        self.assertEqual(efst("* * * * * 50-51/15", start, seconds), [50])
+
+        start = datetime(2024, 7, 11)
+        # The years phase is taken from the field minimum, so it starts at 1970 and is
+        # advanced up into the range: 1970 + ceil((2020 - 1970) / 3) * 3 = 2021.
+        self.assertEqual(
+            efst("0 0 1 1 * 0 2020-2040/3", start, years),
+            [2021, 2024, 2027, 2030, 2033, 2036, 2039],
+        )
+        self.assertEqual(
+            croniter("0 0 1 1 * 0 2020-2040/3", start).expanded[years],
+            [2020, 2023, 2026, 2029, 2032, 2035, 2038],
+        )
+        self.assertEqual(efst("0 0 1 1 * 0 2025-2026/5", start, years), [2025])
+        self.assertEqual(efst("0 0 1 1 * 0 2020-2040", start, years), list(range(2020, 2041)))
+
     def test_expand_from_start_time_does_not_change_a_range_into_another_kind(self):
         """Re-basing must not collide or unwrap the bounds it re-bases.
 
@@ -2893,10 +2929,24 @@ class CroniterTest(base.TestCase):
             return croniter(expr, start_time=start, expand_from_start_time=True).expanded[field]
 
         m, dom, mon, dow = 0, 2, 3, 4
-        # An explicitly written equal range still means the whole cycle, as by default.
+        # An explicitly written equal range still means the whole cycle. A step
+        # written on it is a cycle like any other, so it takes its phase from the
+        # start time -- the same expansion as the wildcard spelling of the schedule.
         self.assertEqual(efst("5-5 * * * *", m), ["*"])
-        self.assertEqual(efst("59-59/15 * * * *", m), [0, 15, 30, 45])
+        self.assertEqual(efst("59-59/15 * * * *", m), [7, 22, 37, 52])
+        self.assertEqual(efst("59-59/15 * * * *", m), efst("*/15 * * * *", m))
+        self.assertEqual(croniter("59-59/15 * * * *", start).expanded[m], [0, 15, 30, 45])
         self.assertEqual(efst("* * * 12-12 *", mon), ["*"])
+        # The month field, where README documents "1-1/3" as Jan/Apr/Jul/Oct.
+        self.assertEqual(
+            croniter(
+                "0 0 1 1-1/3 *", start_time=datetime(2024, 2, 15), expand_from_start_time=True
+            ).expanded[mon],
+            [2, 5, 8, 11],
+        )
+        self.assertEqual(
+            croniter("0 0 1 1-1/3 *", datetime(2024, 2, 15)).expanded[mon], [1, 4, 7, 10]
+        )
         # A range whose phase lands on its own upper bound is not an equal range.
         self.assertEqual(efst("* * 10-11/2 * *", dom), [11])
         self.assertEqual(
@@ -2907,6 +2957,25 @@ class CroniterTest(base.TestCase):
         )
         # A wrapping range stays wrapped.
         self.assertEqual(efst("* * * * 6-0", dow), [0, 6])
+
+    def test_expand_from_start_time_at_the_unix_epoch(self):
+        """A start time of exactly the epoch re-bases like any other.
+
+        The start time reaches the expansion as a timestamp, which is 0.0 here, and
+        the truthiness test that gated re-basing skipped that one instant: the same
+        expression one second later re-based, and this one did not.
+        """
+        epoch = datetime(1970, 1, 1)
+        dow = 4
+
+        def efst(expr, start, field):
+            return croniter(expr, start_time=start, expand_from_start_time=True).expanded[field]
+
+        # The epoch is a Thursday, so the day-of-week phase is 4 % step.
+        self.assertEqual(efst("0 0 * * 2-6/3", epoch, dow), [4])
+        self.assertEqual(efst("0 0 * * 2-6/3", epoch + timedelta(seconds=1), dow), [4])
+        self.assertEqual(croniter("0 0 * * 2-6/3", epoch).expanded[dow], [2, 5])
+        self.assertEqual(efst("0 0 * * */3", epoch, dow), [1, 4])
 
     def test_expand_from_start_time_never_leaves_the_declared_range(self):
         """Property sweep: a re-based expansion may never fall outside its bounds.
@@ -2956,11 +3025,17 @@ class CroniterTest(base.TestCase):
                         self.assertLessEqual(len(rebased), len(plain))
 
     def test_expand_from_start_time_fuzz(self):
-        """Seeded sweep over random expressions: values stay in range, none empty."""
+        """Seeded sweep over random expressions: values stay in range, none empty.
+
+        The optional seconds and years fields are swept alongside the five mandatory
+        ones -- they re-base by the same arithmetic, and only #254 made them reachable.
+        """
         rnd = random.Random(20260801)
         for _ in range(500):
             parts = []
-            for index in range(5):
+            # Five fields always, then the optional seconds and years fields, which are
+            # written after them: "{m} {h} {dom} {mon} {dow} [{sec} [{year}]]".
+            for index in list(range(5)) + [5, 6][: rnd.randint(0, 2)]:
                 lo, hi = croniter.RANGES[index]
                 if rnd.random() < 0.5:
                     parts.append("*")

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2820,6 +2820,25 @@ class CroniterTest(base.TestCase):
                 ).expanded[0]
                 self.assertEqual(seconds, minutes)
 
+    def test_expand_from_start_time_issue_252(self):
+        """The three cases reported in #252, each staying inside its own range.
+
+        "20-40/5" started 18 minutes early and stopped 3 minutes short, and the
+        narrow window "0-1/2" widened to every other minute of the whole field.
+        """
+        start = datetime(2024, 7, 11, 10, 7)
+
+        def efst(expr):
+            return croniter(expr, start_time=start, expand_from_start_time=True).expanded[0]
+
+        self.assertEqual(efst("10-50/15 * * * *"), [22, 37])
+        self.assertEqual(efst("20-40/5 * * * *"), [22, 27, 32, 37])
+        self.assertEqual(efst("0-1/2 * * * *"), [1])
+        # The default expansion of each is unchanged, as #252 notes it should be.
+        self.assertEqual(croniter("10-50/15 * * * *", start).expanded[0], [10, 25, 40])
+        self.assertEqual(croniter("20-40/5 * * * *", start).expanded[0], [20, 25, 30, 35, 40])
+        self.assertEqual(croniter("0-1/2 * * * *", start).expanded[0], [0])
+
     def test_expand_from_start_time_respects_declared_bounds(self):
         """Re-basing supplies the phase of a cycle, never a bound outside the range.
 

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import random
 import unittest
 import zoneinfo
 from datetime import datetime, timedelta
@@ -2887,6 +2888,84 @@ class CroniterTest(base.TestCase):
         )
         # A wrapping range stays wrapped.
         self.assertEqual(efst("* * * * 6-0", dow), [0, 6])
+
+    def test_expand_from_start_time_never_leaves_the_declared_range(self):
+        """Property sweep: a re-based expansion may never fall outside its bounds.
+
+        This is the invariant the whole change exists to establish. Before it, 10,571
+        of 13,332 swept expansions contained at least one value the expression never
+        allowed.
+        """
+        for lo, hi in [(0, 59), (5, 50), (10, 11), (7, 8), (58, 59), (0, 1), (30, 31)]:
+            for step in (1, 2, 3, 7, 15, 60):
+                for minute in (0, 7, 23, 41, 59):
+                    expr = f"{lo}-{hi}/{step} * * * *"
+                    with self.subTest(expr=expr, minute=minute):
+                        got = croniter(
+                            expr,
+                            start_time=datetime(2024, 7, 11, 10, minute),
+                            expand_from_start_time=True,
+                        ).expanded[0]
+                        self.assertTrue(got, "expanded to nothing")
+                        if got == ["*"]:
+                            # Only a written equal range, or a range covering the whole
+                            # field, may legitimately expand to everything.
+                            self.assertTrue(lo == hi or (lo, hi) == (0, 59))
+                            continue
+                        for value in got:
+                            self.assertTrue(lo <= value <= hi, f"{value} outside [{lo}, {hi}]")
+
+    def test_expand_from_start_time_never_adds_fires(self):
+        """Re-phasing may move or thin a schedule, never make it fire more often.
+
+        It can thin one: "10-20/7" is 10,17 by default but 14 alone from a start at
+        minute 7. What it must never do is produce more values than the expression
+        means without the flag, which is what discarding the lower bound did.
+        """
+        for lo, hi in [(0, 59), (5, 50), (10, 20), (30, 31), (2, 9)]:
+            for step in (2, 3, 7, 15):
+                for minute in (0, 7, 23, 41):
+                    expr = f"{lo}-{hi}/{step} * * * *"
+                    start = datetime(2024, 7, 11, 10, minute)
+                    with self.subTest(expr=expr, minute=minute):
+                        plain = croniter(expr, start_time=start).expanded[0]
+                        rebased = croniter(
+                            expr, start_time=start, expand_from_start_time=True
+                        ).expanded[0]
+                        if plain == ["*"] or rebased == ["*"]:
+                            continue
+                        self.assertLessEqual(len(rebased), len(plain))
+
+    def test_expand_from_start_time_fuzz(self):
+        """Seeded sweep over random expressions: values stay in range, none empty."""
+        rnd = random.Random(20260801)
+        for _ in range(500):
+            parts = []
+            for index in range(5):
+                lo, hi = croniter.RANGES[index]
+                if rnd.random() < 0.5:
+                    parts.append("*")
+                    continue
+                a, b = sorted((rnd.randint(lo, hi), rnd.randint(lo, hi)))
+                step = rnd.choice([1, 2, 3, 5, 7, 15, 60])
+                parts.append(
+                    rnd.choice([f"{a}/{step}", f"{a}-{b}/{step}", f"{a}-{b}", f"*/{step}"])
+                )
+            expr = " ".join(parts)
+            start = datetime(2024, 7, 11, 10, 7) + timedelta(minutes=rnd.randint(0, 500000))
+            with self.subTest(expr=expr, start=start):
+                try:
+                    expanded = croniter(
+                        expr, start_time=start, expand_from_start_time=True
+                    ).expanded
+                except CroniterBadCronError:
+                    continue
+                for index, values in enumerate(expanded):
+                    self.assertTrue(values, f"field {index} expanded to nothing")
+                    lo, hi = croniter.RANGES[index]
+                    for value in values:
+                        if value != "*":
+                            self.assertTrue(lo <= value <= hi, f"field {index} value {value}")
 
     def test_get_next_fails_with_expand_from_start_time_true(self):
         expanded_croniter = croniter("0 0 */5 * *", expand_from_start_time=True)


### PR DESCRIPTION
Fixes #252.

`expand_from_start_time` overwrites the lower bound of every range outright rather than supplying the phase of the cycle, so any range whose start is above the field minimum fires below its own start:

```
* 8-17 * * *       hours 0-17, not 8-17     (a business-hours schedule firing at midnight)
* * * * MON-FRI    days 0-5, not 1-5        (includes Sunday)
10-50/15 * * * *   7,22,37 from minute 7    (7 is outside the declared range)
5-5 * * * *        0-5, not the whole cycle (the equal-range rule is destroyed)
* * * * 6-0        every day, not Sat+Sun   (the wrap is unwrapped)
```

The `10-50/15` case is the one @earfman found in #246 and offered to file separately; it turned out to be one symptom of a much wider problem.

## The fix

Re-basing now supplies the phase and nothing else:

- advance the phase to the first value inside the declared range;
- where no value of the phase fits, honour the expression as written.

So re-basing can neither invent a fire outside the range nor drop one the range asks for. A wrapping range has no single in-range phase, so it is left alone rather than silently unwrapped.

An explicitly written equal range means the whole cycle, and it is widened to the field's own bounds *before* re-basing, so that cycle takes its phase from `start_time` like any other: `1-1/3` and `*/3` in the month field are the same expression and now agree under the flag as well. The `{start}/{step}` collision at the field maximum is held out of that — widening `59/15` would re-open #246.

## This answers the question #246 left open

`45/15` under `expand_from_start_time` goes from `[7, 22, 37, 52]` to `[52]` — one fire an hour, which is what `45/15` already means without the flag. #246 deliberately did not decide this; the assertion pinning the old value is updated here, with a pointer to the new test.

## Containment

101,088 `expand_from_start_time` expansions — all seven fields, every legal lower bound, eight token shapes, seven steps, four start times — against #246's head:

- expansions containing a value outside the range the expression declares: **73,898 → 0**
- 93,456 differ; the untouched shapes are the plain wildcard, the bare value, and `*/step` except where the step is wide enough to collide the field's own bounds (`*/60` in the minute field re-based to minute 0 rather than to its phase)
- default-mode expansions do not move at all; no expansion became empty; no error status changed
- against the **default** expansion of the same expression, no re-based expansion fires more often, 13,539 fire less, and never by more than one period
- against the **old flag** behaviour, 17,038 fire more often — every one an explicit equal range or a wrapping range, i.e. the two shapes the old code re-read as something else

This is a large behaviour change and the release note says so. Every affected schedule was firing outside what it declared.
