### PR TITLE
Take the expand_from_start_time phase from the start time's own timezone

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,17 @@ Bugfixes
   clamped to the declared range and emitted as a single value when the step cannot
   reach a second one. Divisors that fit their range keep their existing hashes, so no
   schedule that was already correct moves. [#253, @potiuk]
+- Fix ``expand_from_start_time`` taking the phase of a cycle from the UTC form of a
+  timezone-aware ``start_time`` rather than from the wall clock the caller wrote.
+  ``_get_low_from_current_date_number`` read the start time back with ``tz=UTC``, so
+  ``0 */5 * * *`` from ``2025-01-01 05:00+13:00`` phased on UTC hour 16 and expanded to
+  hours ``1,6,11,16,21`` instead of ``0,5,10,15,20``. The hour, day-of-month, month and
+  day-of-week fields were all affected, and at a date boundary the day and month could
+  be a whole day or month out. The start time's own ``tzinfo`` is now carried into the
+  expansion. A naive ``start_time`` is converted to a timestamp as if it were UTC, so
+  UTC round-trips it to the same wall clock and naive callers see no change at all —
+  verified over 45,312 expansions with naive start times, none of which differ.
+  [#256, @potiuk]
 
 Packaging
 ~~~~~~~~~

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -330,6 +330,7 @@ class croniter:
             expr_format,
             hash_id=hash_id,
             from_timestamp=self.dst_start_time if self._expand_from_start_time else None,
+            from_timestamp_tz=self.tzinfo if self._expand_from_start_time else None,
             second_at_beginning=second_at_beginning,
         )
         self.fields = CRON_FIELDS[len(self.expanded)]
@@ -941,7 +942,7 @@ class croniter:
     DAYS_IN_MONTH = {1: 31, 2: 28, 3: 31, 4: 30, 5: 31, 6: 30, 7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31}
 
     @classmethod
-    def _expand(cls, expr_format, hash_id=None, second_at_beginning=False, from_timestamp=None, strict=False, strict_year=None):
+    def _expand(cls, expr_format, hash_id=None, second_at_beginning=False, from_timestamp=None, from_timestamp_tz=None, strict=False, strict_year=None):
         # Split the expression in components, and normalize L -> l, MON -> mon,
         # etc. Keep expr_format untouched so we can use it in the exception
         # messages.
@@ -1106,7 +1107,7 @@ class croniter:
 
                     if from_timestamp:
                         low = cls._get_low_from_current_date_number(
-                            field_index, int(step), int(from_timestamp)
+                            field_index, int(step), int(from_timestamp), from_timestamp_tz
                         )
 
                     # Handle when the second bound of the range is in backtracking order:
@@ -1243,6 +1244,7 @@ class croniter:
         hash_id: Optional[Union[bytes, str]] = None,
         second_at_beginning: bool = False,
         from_timestamp: Optional[float] = None,
+        from_timestamp_tz: Optional[datetime.tzinfo] = None,
         strict: bool = False,
         strict_year: Optional[Union[int, list[int]]] = None,
     ) -> tuple[list[ExpandedExpression], dict[int, set[int]]]:
@@ -1290,6 +1292,7 @@ class croniter:
                 hash_id=hash_id,
                 second_at_beginning=second_at_beginning,
                 from_timestamp=from_timestamp,
+                from_timestamp_tz=from_timestamp_tz,
                 strict=strict,
                 strict_year=strict_year,
             )
@@ -1301,8 +1304,11 @@ class croniter:
             raise CroniterBadCronError(trace)
 
     @classmethod
-    def _get_low_from_current_date_number(cls, field_index, step, from_timestamp):
-        dt = datetime.datetime.fromtimestamp(from_timestamp, tz=UTC_DT)
+    def _get_low_from_current_date_number(cls, field_index, step, from_timestamp, tzinfo=None):
+        # Read the start time back in its own timezone. A naive start_time was
+        # converted to a timestamp as if it were UTC, so UTC round-trips it to the
+        # same wall clock and nothing changes for that case.
+        dt = datetime.datetime.fromtimestamp(from_timestamp, tz=tzinfo or UTC_DT)
         if field_index == MINUTE_FIELD:
             return dt.minute % step
         if field_index == HOUR_FIELD:

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2528,6 +2528,42 @@ class CroniterTest(base.TestCase):
         fires = [itr.get_next(datetime) for _ in range(4)]
         self.assertIn(datetime(2024, 7, 21), fires)
 
+    def test_expand_from_start_time_uses_the_start_times_own_timezone(self):
+        """The phase comes from the start time's wall clock, not from its UTC form.
+
+        _get_low_from_current_date_number read the timestamp back in UTC, so a
+        timezone-aware start_time phased on the UTC hour, day and month rather than
+        on the local ones the caller wrote.
+        """
+        auckland = zoneinfo.ZoneInfo("Pacific/Auckland")
+        local = datetime(2025, 1, 1, 5, 0, tzinfo=auckland)
+        # The same instant is a different hour, day, month and year in UTC.
+        utc_view = local.astimezone(zoneinfo.ZoneInfo("UTC"))
+        self.assertEqual((utc_view.hour, utc_view.day, utc_view.month), (16, 31, 12))
+
+        def efst(expr, field, start):
+            return croniter(expr, start_time=start, expand_from_start_time=True).expanded[field]
+
+        # Local hour 5 gives phase 0; the UTC hour 16 would have given phase 1.
+        self.assertEqual(efst("0 */5 * * *", 1, local), [0, 5, 10, 15, 20])
+        # Local month 1 gives phase 1; the UTC month 12 would have given phase 2.
+        self.assertEqual(efst("0 0 1 */5 *", 3, local), [1, 6, 11])
+
+    def test_expand_from_start_time_naive_start_is_unaffected_by_timezone_handling(self):
+        """A naive start_time is converted as if it were UTC, so it round-trips."""
+
+        def efst(expr, field, start):
+            return croniter(expr, start_time=start, expand_from_start_time=True).expanded[field]
+
+        naive = datetime(2024, 7, 11, 10, 7)
+        self.assertEqual(efst("*/15 * * * *", 0, naive), [7, 22, 37, 52])
+        self.assertEqual(efst("0 */5 * * *", 1, naive), [0, 5, 10, 15, 20])
+        self.assertEqual(efst("0 0 */5 * *", 2, naive), [1, 6, 11, 16, 21, 26, 31])
+        # An explicitly-UTC start time must agree with the naive one.
+        aware = naive.replace(tzinfo=zoneinfo.ZoneInfo("UTC"))
+        for expr, field in (("*/15 * * * *", 0), ("0 */5 * * *", 1), ("0 0 */5 * *", 2)):
+            self.assertEqual(efst(expr, field, aware), efst(expr, field, naive))
+
     def test_get_next_fails_with_expand_from_start_time_true(self):
         expanded_croniter = croniter("0 0 */5 * *", expand_from_start_time=True)
         self.assertRaises(

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2564,6 +2564,43 @@ class CroniterTest(base.TestCase):
         for expr, field in (("*/15 * * * *", 0), ("0 */5 * * *", 1), ("0 0 */5 * *", 2)):
             self.assertEqual(efst(expr, field, aware), efst(expr, field, naive))
 
+    def test_expand_from_start_time_timezone_invariants(self):
+        """Property sweep: the phase must always match the local wall clock.
+
+        Across zones on both sides of UTC, and instants that straddle a date
+        boundary, every re-based field must take its phase from the field value the
+        caller would read off the start time, never from its UTC form.
+        """
+        zones = [
+            "UTC",
+            "Europe/Warsaw",
+            "America/New_York",
+            "Pacific/Auckland",
+            "Asia/Kolkata",
+            "Pacific/Kiritimati",
+        ]
+        instants = [
+            datetime(2025, 1, 1, 5, 0),
+            datetime(2024, 7, 11, 10, 7),
+            datetime(2024, 12, 31, 23, 30),
+        ]
+        cases = [
+            ("0 */5 * * *", 1, "hour"),
+            ("0 0 */5 * *", 2, "day"),
+            ("0 0 1 */5 *", 3, "month"),
+        ]
+        for zone in zones:
+            for instant in instants:
+                start = instant.replace(tzinfo=zoneinfo.ZoneInfo(zone))
+                for expr, field, attribute in cases:
+                    with self.subTest(zone=zone, instant=instant, expr=expr):
+                        got = croniter(
+                            expr, start_time=start, expand_from_start_time=True
+                        ).expanded[field]
+                        local = getattr(start, attribute)
+                        lo = croniter.RANGES[field][0]
+                        self.assertIn(((local - lo) % 5) + lo, got)
+
     def test_get_next_fails_with_expand_from_start_time_true(self):
         expanded_croniter = croniter("0 0 */5 * *", expand_from_start_time=True)
         self.assertRaises(


### PR DESCRIPTION
Found by an adversarial pass over #246/#253/#254/#255 — the one probe the whole stack still tripped.

`_get_low_from_current_date_number` reads the start timestamp back with `tz=UTC`, so a timezone-aware `start_time` phases its cycles on the UTC wall clock instead of the one the caller wrote:

```python
from datetime import datetime
from zoneinfo import ZoneInfo
from croniter import croniter

start = datetime(2025, 1, 1, 5, 0, tzinfo=ZoneInfo("Pacific/Auckland"))  # 2024-12-31 16:00 UTC
croniter("0 */5 * * *", start, expand_from_start_time=True).expanded[1]
# [1, 6, 11, 16, 21]   <- phased on UTC hour 16
# [0, 5, 10, 15, 20]   <- what local hour 5 asks for
```

Hour, day-of-month, month and day-of-week are all affected. At a date boundary the day and month can be a whole day or month out — above, the local date is 1 January but the phase is taken from 31 December.

`self.tzinfo` is already resolved in `set_current()` before `_expand()` runs; it was simply never carried through. This threads it down to the phase calculation.

## Naive start times are untouched

`datetime_to_timestamp` converts a naive `datetime` as if it were UTC, so reading it back as UTC round-trips to the same wall clock. `tz=tzinfo or UTC_DT` is therefore a no-op for naive callers. Verified over a 45,312-expansion sweep with naive start times: **zero differences**.

An explicitly-UTC `start_time` also agrees with the naive one, and there is a test pinning that.

## Blast radius

Only timezone-aware `start_time` with `expand_from_start_time=True`, and only where the zone's offset moves the field across a boundary. Over 744 combinations of six zones, four base instants and the stepped forms, 215 change — all of them from the UTC phase to the local one.

## Ordering

Independent of #246, #253, #254 and #255 — different code. It touches `_get_low_from_current_date_number`, which #254 also extends, so whichever lands second needs a trivial rebase.
