### PR TITLE
Document what expand_from_start_time means, and the equal-range rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,15 @@ Bugfixes
   visible: a start of ``2025-01-01 05:00+13:00`` is ``2024`` in UTC, so the year phase
   is a whole year off.
 
+Testing and Documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+- Document what ``expand_from_start_time`` actually means — that it moves the phase of a
+  cycle and not the values a field may take, that every field re-bases including the
+  optional seconds and years, and that the phase is read in the start time's own
+  timezone. Also document that a range with two equal bounds (``Jan-Jan``, ``Sun-Sun``)
+  means the whole cycle rather than the value it names, which was undocumented and is
+  the rule behind several of the bugs fixed in this release. [#257, @potiuk]
+
 Packaging
 ~~~~~~~~~
 - Bump pinned GitHub Actions via dependabot. [6e69553, #247; 3c6ce9b, #251]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,13 +39,6 @@ Bugfixes
   not start at zero — take theirs from the field minimum, as day-of-month and month
   already do. [#254, @potiuk]
 
-  Note that ``_get_low_from_current_date_number`` reads the start time in UTC, so for a
-  timezone-aware ``start_time`` the phase is taken from the UTC hour, day, month and now
-  year rather than the local one. That is pre-existing — ``0 */5 * * *`` already phases
-  on the UTC hour — and is not addressed here, but the year field is where it is most
-  visible: a start of ``2025-01-01 05:00+13:00`` is ``2024`` in UTC, so the year phase
-  is a whole year off.
-
 Testing and Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 - Document what ``expand_from_start_time`` actually means — that it moves the phase of a

--- a/README.rst
+++ b/README.rst
@@ -291,7 +291,31 @@ To ignore second repetition, simply set second to ``0`` or any other const::
 Support for start_time shifts
 ==============================
 See https://github.com/pallets-eco/croniter/pull/76,
-You can set start_time=, then expand_from_start_time=True for your generations to be computed from start_time instead of calendar days::
+You can set start_time=, then expand_from_start_time=True for your generations to be computed from start_time instead of calendar days.
+
+**What the flag means.** ``expand_from_start_time`` changes where a *cycle*
+starts. For a field written with a step, the phase of that cycle is taken from
+the corresponding field of ``start_time`` instead of from the field's own
+minimum::
+
+    >>> croniter('*/15 * * * *', datetime(2024, 7, 11, 10, 7), expand_from_start_time=True).expanded[0]
+    [7, 22, 37, 52]
+    >>> croniter('*/15 * * * *', datetime(2024, 7, 11, 10, 7)).expanded[0]
+    [0, 15, 30, 45]
+
+Every field re-bases, including the optional seconds and years fields. Seconds
+take their phase from the start time's second. Day-of-month, month and year do
+not start at zero, so they take theirs from the field minimum rather than from
+the value itself.
+
+The phase is read from ``start_time`` in **its own timezone**, so a
+timezone-aware start time phases on the local wall clock, not on its UTC form::
+
+    >>> start = datetime(2024, 7, 11, 10, 7, tzinfo=ZoneInfo('Pacific/Auckland'))  # 22:07 UTC
+    >>> croniter('0 */5 * * *', start, expand_from_start_time=True).expanded[1]
+    [0, 5, 10, 15, 20]
+
+A worked example::
 
     >>> from pprint import pprint
     >>> iter = croniter('0 0 */7 * *', start_time=datetime(2024, 7, 11), expand_from_start_time=True);pprint([iter.get_next(datetime) for a in range(10)])
@@ -448,6 +472,18 @@ Note that as a deviation from cron standard, croniter is somehow laxist with ran
     - ``Wed-Sun``: Wednesday to Saturday, Sunday
 
 Please note that if a /step is given, it will be respected.
+
+A range whose two bounds are equal is a further deviation: it means the **whole
+cycle**, not the single value it names. This applies in every field::
+
+    >>> croniter('0 0 * JAN-JAN *').expanded[3]
+    ['*']
+    >>> croniter('0 0 * * SUN-SUN').expanded[4]
+    ['*']
+
+So ``Jan-Jan`` is every month, not January. A step is applied across that whole
+cycle, so ``1-1/3`` in the month field is January, April, July and October. To
+name a single value, write it on its own — ``1`` or ``JAN``.
 
 Note about Sunday
 =================


### PR DESCRIPTION
Two rules the code has always had and the README never stated. Between them they account for most of the bugs fixed in this release.

**An equal range means the whole cycle.** `Jan-Jan` is every month, not January. This is croniter-specific and was documented nowhere — yet it is exactly what `59/15` collided with in #246, since `{start}/{step}` normalizes to `{start}-{max}/{step}`. Added to "Note about Ranges", next to the reverse-range deviation it sits beside.

**`expand_from_start_time` had no definition at all** — the section was a worked example and a link to #76. Every field interpreted "re-base on the start time" for itself, which is why it has been fixed in a different field in each of the last three releases: the month low bound in 6.2.3, the day-of-week wrap in 6.2.4, and seconds/years (#254) and the timezone (#256) in this one. The section now states the rule the fixes converged on:

- it moves the *phase* of a cycle, not the values a field may take;
- every field re-bases, including the optional seconds and years;
- fields that do not start at zero take their phase from the field minimum;
- the phase is read in the start time's own timezone, not its UTC form.

## Verification

README is not doctested, but it is the PyPI long description, so all six added examples were executed against `main` and match exactly. `docutils` parses the file with zero warnings, unchanged from before.

## Note

One line is deliberately missing: *the bounds come from the expression*. That is not true on `main` yet — it is what #255 establishes — so it belongs in that PR rather than here.
