### PR TITLE
Compare instants, not wall clocks, in croniter_range

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,22 @@ Changelog
 
 Bugfixes
 ~~~~~~~~
+- Fix ``croniter_range`` deciding both its direction and its stop condition from
+  wall-clock readings rather than instants. Comparing two aware datetimes that
+  share a ``tzinfo`` ignores that ``tzinfo`` and compares the base datetimes, and
+  ``fold`` is part of neither, so across a DST transition the comparison
+  disagrees with the order the fire times actually occur in. The one-microsecond
+  nudge that makes the bounds inclusive had the same defect: arithmetic on an
+  aware datetime moves the wall clock and resets ``fold``, so a one-microsecond
+  step could move a bound by a whole DST offset. A four-minute interval inside
+  the ``Australia/Sydney`` fall-back hour returned 1 of its 6 fire times, ending
+  the generator early with no exception; a reverse range over the
+  ``Europe/London`` spring-forward yielded a fire time 15 minutes below the
+  requested lower bound; and a forward interval whose bounds read backwards on
+  the wall clock ran backwards. Bounds and fire times are now compared as
+  instants, and the inclusive-ends nudge moves by real elapsed time. Naive
+  datetimes are unaffected, and no range that does not cross an offset change
+  moves. [#259, @hdimer]
 - Fix ``get_next``/``get_prev`` raising ``CroniterBadDateError`` when day-of-month and day-of-week are both restricted and the day-of-month can never occur in the selected month (e.g. ``0 0 31 2 0``). Under the Vixie OR semantics the unsatisfiable side now contributes no dates instead of aborting the whole expression, and ``match()`` and ``croniter_range()``, which swallow the error, no longer return silently wrong results for these expressions. [b245ab6, #243, @semx, @MildlyMeticulous]
 - Fix hashed divisions (``H/{divisor}``, ``H({begin}-{end})/{divisor}``) when the divisor
   is as wide as, or wider than, the range it is drawn from. Three symptoms, one cause:

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -167,6 +167,29 @@ def _is_successor(
     return date.astimezone(UTC_DT) > previous_date.astimezone(UTC_DT)
 
 
+def _instant(date: datetime.datetime) -> datetime.datetime:
+    """Return a form of the given date that orders by real elapsed time.
+
+    Comparing two aware datetimes that share a tzinfo ignores that tzinfo and
+    compares the wall clocks, so across a DST transition the comparison
+    disagrees with the order the instants actually occurred in.
+    """
+    if date.utcoffset() is None:
+        return date
+    return date.astimezone(UTC_DT)
+
+
+def _shift(date: datetime.datetime, delta: relativedelta) -> datetime.datetime:
+    """Move the given date by delta of real elapsed time, keeping its timezone.
+
+    Arithmetic on an aware datetime moves the wall clock and resets ``fold``, so
+    a step of one microsecond can move the instant by a whole DST offset.
+    """
+    if date.utcoffset() is None:
+        return date + delta
+    return (_instant(date) + delta).astimezone(date.tzinfo)
+
+
 def _timezone_delta(date1: datetime.datetime, date2: datetime.datetime) -> datetime.timedelta:
     """Calculate the timezone difference of the given dates."""
     offset1 = date1.utcoffset()
@@ -1451,14 +1474,15 @@ def croniter_range(
         auto_rt = float
     if ret_type is None:
         ret_type = auto_rt
+    forward = _instant(start) < _instant(stop)
     if not exclude_ends:
         ms1 = relativedelta(microseconds=1)
-        if start < stop:  # Forward (normal) time order
-            start -= ms1
-            stop += ms1
+        if forward:  # Forward (normal) time order
+            start = _shift(start, -ms1)
+            stop = _shift(stop, ms1)
         else:  # Reverse time order
-            start += ms1
-            stop -= ms1
+            start = _shift(start, ms1)
+            stop = _shift(stop, -ms1)
     year_span = math.floor(abs(stop.year - start.year)) + 1
     ic = _croniter(
         expr_format,
@@ -1470,16 +1494,17 @@ def croniter_range(
         expand_from_start_time=expand_from_start_time,
     )
     # define a continue (cont) condition function and step function for the main while loop
-    if start < stop:  # Forward
+    stop_instant = _instant(stop)
+    if forward:
 
         def cont(v):
-            return v < stop
+            return _instant(v) < stop_instant
 
         step = ic.get_next
     else:  # Reverse
 
         def cont(v):
-            return v > stop
+            return _instant(v) > stop_instant
 
         step = ic.get_prev
     try:

--- a/src/croniter/tests/test_croniter_range.py
+++ b/src/croniter/tests/test_croniter_range.py
@@ -226,6 +226,58 @@ class CroniterRangeTest(base.TestCase):
             [(2, 1), (2, 8), (2, 15), (2, 22)],
         )
 
+    def test_fold_does_not_truncate_the_range(self):
+        """Both bounds sit in the repeated hour, so the wall clock runs backwards."""
+        tz = zoneinfo.ZoneInfo("Australia/Sydney")
+        start = datetime(2019, 4, 7, 2, 22, tzinfo=tz)  # +11:00, UTC 15:22
+        stop = datetime(2019, 4, 7, 2, 26, tzinfo=tz, fold=1)  # +10:00, UTC 16:26
+        fwd = list(croniter_range(start, stop, "*/13 * * * *"))
+        self.assertEqual(
+            [d.isoformat() for d in fwd],
+            [
+                "2019-04-07T02:26:00+11:00",
+                "2019-04-07T02:39:00+11:00",
+                "2019-04-07T02:52:00+11:00",
+                "2019-04-07T02:00:00+10:00",
+                "2019-04-07T02:13:00+10:00",
+                "2019-04-07T02:26:00+10:00",
+            ],
+        )
+        excl = list(croniter_range(start, stop, "*/13 * * * *", exclude_ends=True))
+        self.assertEqual([d.isoformat() for d in excl], [d.isoformat() for d in fwd[:-1]])
+
+    def test_offset_change_does_not_yield_outside_the_range(self):
+        """Bounds straddling spring-forward carry different offsets; fold is not involved."""
+        tz = zoneinfo.ZoneInfo("Europe/London")
+        lower = datetime(2018, 3, 25, 1, 15, tzinfo=tz)  # GMT, UTC 01:15
+        upper = datetime(2018, 3, 25, 5, 0, tzinfo=tz)  # BST, UTC 04:00
+        rev = list(croniter_range(upper, lower, "0 * * * *"))
+        self.assertEqual(
+            [d.isoformat() for d in rev],
+            [
+                "2018-03-25T05:00:00+01:00",
+                "2018-03-25T04:00:00+01:00",
+                "2018-03-25T03:00:00+01:00",
+            ],
+        )
+
+    def test_direction_follows_the_instants_not_the_wall_clock(self):
+        """stop is after start in real time but earlier on the wall clock."""
+        tz = zoneinfo.ZoneInfo("Australia/Sydney")
+        start = datetime(2019, 4, 7, 2, 39, tzinfo=tz)  # +11:00, UTC 15:39
+        stop = datetime(2019, 4, 7, 2, 26, tzinfo=tz, fold=1)  # +10:00, UTC 16:26
+        fwd = list(croniter_range(start, stop, "*/13 * * * *"))
+        self.assertEqual(
+            [d.isoformat() for d in fwd],
+            [
+                "2019-04-07T02:39:00+11:00",
+                "2019-04-07T02:52:00+11:00",
+                "2019-04-07T02:00:00+10:00",
+                "2019-04-07T02:13:00+10:00",
+                "2019-04-07T02:26:00+10:00",
+            ],
+        )
+
     def test_year_range(self):
         start = datetime(2010, 1, 1)
         stop = datetime(2030, 1, 1)


### PR DESCRIPTION
Fixes #259.

`croniter_range` decides both its iteration direction and its stop condition
with `start < stop` and `v < stop`. CPython specifies that comparing two aware
datetimes that share a `tzinfo` ignores that `tzinfo` and compares the base
datetimes, and `fold` is part of neither, so across a DST transition those
comparisons use wall-clock order rather than real elapsed time.

The one-microsecond nudge that makes the bounds inclusive has the same defect
from the other side: arithmetic on an aware datetime moves the wall clock and
resets `fold`, so a one-microsecond step can move a bound by a whole DST
offset. Fixing only the comparison is not enough — the nudge puts the bound
back on the wrong side.

### Three symptoms, one cause

**Silently returns too few results.** `Australia/Sydney`, a four-minute
interval inside the fall-back hour, contains six fire times:

```python
tz = zoneinfo.ZoneInfo("Australia/Sydney")
start = datetime(2019, 4, 7, 2, 22, tzinfo=tz)          # +11:00, UTC 15:22
stop  = datetime(2019, 4, 7, 2, 26, tzinfo=tz, fold=1)  # +10:00, UTC 16:26

len(list(croniter_range(start, stop, "*/13 * * * *")))  # 1, expected 6
```

The generator ends early. No exception, no warning — the caller gets a prefix
of the correct answer.

**Returns results outside the requested interval.** `Europe/London`, a reverse
range across spring-forward, yields a fire time at UTC 01:00 for a lower bound
of UTC 01:15.

**Runs in the wrong direction.** A forward interval whose bounds happen to read
backwards on the wall clock (`02:39+11:00` → `02:26+10:00`, which is forwards in
real time) iterates backwards and yields values below the requested start.

In all three cases, stepping the underlying `croniter` over the same window
gives the right answer, so `croniter_range` was answering a question its own
iterator already answers correctly.

### The change

Two small module-level helpers, `_instant` and `_shift`, and three rewired
comparison sites in `croniter_range`. `_instant` normalises an aware datetime to
UTC for ordering and returns a naive one unchanged; `_shift` moves a bound by
real elapsed time instead of wall-clock time. The existing `_is_successor` does
the same UTC-normalised comparison for `get_next`/`get_prev`, so this brings
`croniter_range` in line with the rest of the module.

I did not fold `cont` into `_is_successor`: that helper calls `astimezone`
unguarded, which for a naive datetime would silently assume the machine's local
zone, and `croniter_range`'s naive path is the common one.

### Verification

- Three tests in `test_croniter_range.py`, one per symptom. Each fails on
  `main` for its own reason and passes after. They assert on local-time
  `isoformat()` strings, matching the neighbouring DST tests, so the expected
  values show the wall clock running backwards while the sequence advances.
- Full suite: 251 passed, 92 subtests.
- Differential sweep, 768 ordinary ranges (6 zones including naive and UTC, 4
  expressions, both directions, both `exclude_ends`): **zero** differences
  against `main`. The change is inert unless a bound is ambiguous or the bounds
  carry different offsets.
- Invariant check over ~118,000 generated DST-crossing ranges across 10 zones,
  including the 30-minute (`Australia/Lord_Howe`) and 45-minute
  (`Pacific/Chatham`) shifts, asserting every yielded instant falls inside the
  requested bounds and the sequence is monotonic in real time: `main` violates
  those invariants ~11,000 times, this branch zero times.
- `pytz` is unaffected either way, and I verified that: `pytz` never shares a
  `tzinfo` instance across a transition, so its comparisons were already
  ordering by instant. The `fold` half of this is `zoneinfo`-specific.

### Out of scope

While checking `croniter_range` against `get_next` as an oracle I hit a
disagreement confined to `Australia/Lord_Howe`: `get_next` skips a fire time
that `get_prev` and `match` both accept. That is the separate `_add_tzinfo`
issue reported in #258 — it reproduces with a bare `croniter(...)` and no
`croniter_range` involved, and this branch does not touch it.

---
Used AI assistance on this; I reviewed and tested the change myself.