### PR TITLE
fix: accept day-of-week 7 (Sunday) in the seconds and year cron forms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ Changelog
 
 Bugfixes
 ~~~~~~~~
+- Fix day-of-week ``7`` (Sunday) being rejected in the 6-field (seconds) and 7-field
+  (year) forms. ``7`` is now accepted as an alias for ``0`` in every form, as it already
+  was in the classic 5-field form. [#263, @nikolauspschuetz]
 - Fix ``get_next``/``get_prev`` raising ``CroniterBadDateError`` when day-of-month and day-of-week are both restricted and the day-of-month can never occur in the selected month (e.g. ``0 0 31 2 0``). Under the Vixie OR semantics the unsatisfiable side now contributes no dates instead of aborting the whole expression, and ``match()`` and ``croniter_range()``, which swallow the error, no longer return silently wrong results for these expressions. [b245ab6, #243, @semx, @MildlyMeticulous]
 - Fix hashed divisions (``H/{divisor}``, ``H({begin}-{end})/{divisor}``) when the divisor
   is as wide as, or wider than, the range it is drawn from. Three symptoms, one cause:

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -929,9 +929,9 @@ class croniter:
             # 6fields second repeat form or 7 fields year form
             # but still let conversion happen if day field is shifted
             (field_index in [DAY_FIELD, MONTH_FIELD] and len_expressions == UNIX_CRON_LEN)
-            or (field_index in [MONTH_FIELD, DOW_FIELD] and len_expressions == SECOND_CRON_LEN)
+            or (field_index in [MONTH_FIELD] and len_expressions == SECOND_CRON_LEN)
             or (
-                field_index in [DAY_FIELD, MONTH_FIELD, DOW_FIELD]
+                field_index in [DAY_FIELD, MONTH_FIELD]
                 and len_expressions == YEAR_CRON_LEN
             )
         ):

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -2933,6 +2933,15 @@ class CroniterTest(base.TestCase):
         self.assertTrue(croniter.is_valid("* * * * 1-7"))
         self.assertTrue(croniter.is_valid("* * * * 7"))
 
+    def test_dow7_sunday_in_second_and_year_forms(self):
+        # Sunday is 0 or 7 in every field-count form, not only the 5-field one
+        for expr, sunday in [
+            ("0 0 * * 7 0", "0 0 * * 0 0"),  # 6 fields (seconds)
+            ("0 0 * * 7 0 *", "0 0 * * 0 0 *"),  # 7 fields (seconds + year)
+        ]:
+            self.assertTrue(croniter.is_valid(expr))
+            self.assertEqual(croniter.expand(expr)[0][4], croniter.expand(sunday)[0][4])
+
     def test_sunday_ranges_to(self):
         self._test_sunday_ranges("0 0 * * Sun-Sun", list(range(2, 32)))
         self._test_sunday_ranges("0 0 * * Mon-Sun", list(range(2, 32)))


### PR DESCRIPTION
`7` is a standard alias for Sunday (`0`), and croniter accepts it in the classic 5-field form. `value_alias` skipped the `7 -> 0` conversion in the 6-field (seconds) and 7-field (year) forms, so `7` was rejected there as out of range:

```python
>>> croniter.is_valid("0 0 * * 7")      # 5-field
True
>>> croniter.is_valid("0 0 * * 7 0")    # 6-field
False
>>> croniter.is_valid("0 0 * * 7 0 *")  # 7-field
False
```

The guard is there to keep rejecting `0` as a day/month in those forms; day-of-week was swept into it. Dropping day-of-week from the two branches makes `7 -> Sunday` work in every form while leaving the month/day `0` rejection unchanged. Regression test added; full suite green.
