### PR TITLE
Do not report a gap-shifted DST alternative as a fire time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ Changelog
 
 Bugfixes
 ~~~~~~~~
+- Fix ``get_prev``, ``match`` and ``croniter_range`` reporting a DST gap shift as a fire time
+  that ``get_next`` skips. When a cron slot fell into a spring-forward gap and resolving the
+  alternative across the offset change walked forward to the next existing wall clock, that
+  manufactured wall clock was returned although its fields did not match the expression: for
+  ``0 * * * *`` in ``Australia/Lord_Howe``, whose transition is only 30 minutes, ``get_prev``
+  from 03:00 landed on 02:30 and ``match(02:30)`` was true while ``get_next`` skipped it. A
+  shifted alternative is now discarded like the regular candidate already was when hours are
+  wildcarded, so the three APIs agree again. [#266, @abhijeet117]
 - Fix ``get_next``/``get_prev`` raising ``CroniterBadDateError`` when day-of-month and day-of-week are both restricted and the day-of-month can never occur in the selected month (e.g. ``0 0 31 2 0``). Under the Vixie OR semantics the unsatisfiable side now contributes no dates instead of aborting the whole expression, and ``match()`` and ``croniter_range()``, which swallow the error, no longer return silently wrong results for these expressions. [b245ab6, #243, @semx, @MildlyMeticulous]
 - Fix hashed divisions (``H/{divisor}``, ``H({begin}-{end})/{divisor}``) when the divisor
   is as wide as, or wider than, the range it is drawn from. Three symptoms, one cause:

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -809,6 +809,13 @@ class croniter:
             )
             alternative_aware_time, exists = _add_tzinfo(alternative_unaware_time, now, is_prev)
 
+            if not exists:
+                # The alternative crossed a DST gap and was shifted forward to
+                # the next existing wall clock. Such a manufactured time is not
+                # a fire time the expression names, so keep the regular
+                # candidate instead.
+                return aware_time
+
             if not _is_successor(alternative_aware_time, now, is_prev):
                 # The alternative time is an ancestor of now. Thus it is not an alternative.
                 return aware_time

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1835,6 +1835,45 @@ class CroniterTest(base.TestCase):
             ],
         )
 
+    def test_dst_gap_shift_is_not_a_fire_time(self):
+        """Lord Howe jumps forward by 30 minutes: 02:00 (+10:30) -> 02:30 (+11:00).
+
+        For the hourly schedule ``0 * * * *`` the 02:00 slot does not exist on
+        2019-10-06, and shifting it lands on 02:30, which the expression does
+        not name (minute 30 vs minute 0). ``get_next`` skips such a shifted
+        time; ``get_prev`` and ``match`` must not present it as a fire time.
+        """
+        tz = zoneinfo.ZoneInfo("Australia/Lord_Howe")
+        start = datetime(2019, 10, 6, 1, 43, tzinfo=tz)
+        nxt = croniter("0 * * * *", start).get_next(datetime)
+        self.assertEqual(nxt.isoformat(), "2019-10-06T03:00:00+11:00")
+
+        prv = croniter("0 * * * *", nxt).get_prev(datetime)
+        self.assertEqual(prv.isoformat(), "2019-10-06T01:00:00+10:30")
+        self.assertLess(prv, start)
+
+        self.assertFalse(croniter.match("0 * * * *", datetime(2019, 10, 6, 2, 30, tzinfo=tz)))
+        # 02:30 is a legitimate fire time when the expression names minute 30.
+        self.assertTrue(croniter.match("0,30 * * * *", datetime(2019, 10, 6, 2, 30, tzinfo=tz)))
+
+    def test_dst_gap_shift_is_not_a_fire_time_pytz(self):
+        """Lord Howe jumps forward by 30 minutes: 02:00 (+10:30) -> 02:30 (+11:00).
+
+        Same schedule as the zoneinfo variant: a gap-shifted wall clock must
+        not be reported by ``get_prev`` or ``match`` as a fire time of ``0 *
+        * * *``.
+        """
+        tz = pytz.timezone("Australia/Lord_Howe")
+        start = tz.localize(datetime(2019, 10, 6, 1, 43))
+        nxt = croniter("0 * * * *", start).get_next(datetime)
+        self.assertEqual(nxt.isoformat(), "2019-10-06T03:00:00+11:00")
+
+        prv = croniter("0 * * * *", nxt).get_prev(datetime)
+        self.assertEqual(prv.isoformat(), "2019-10-06T01:00:00+10:30")
+        self.assertLess(prv, start)
+
+        self.assertFalse(croniter.match("0 * * * *", tz.localize(datetime(2019, 10, 6, 2, 30))))
+
     def test_nth_wday_simple(self):
         def f(y, m, w):
             return croniter._get_nth_weekday_of_month(y, m, w)


### PR DESCRIPTION
## Summary
For an hourly schedule in Australia/Lord_Howe, the only zone with a 30-minute DST shift, get_next, get_prev and match disagreed about whether the gap-manufactured 02:30 wall clock fires. When a slot fell into the spring-forward gap, the alternative resolution across the offset change walked forward to the next existing wall clock and returned it although its fields did not match the expression. Such an alternative is now discarded when its resolution had to be shifted, mirroring the wildcard-hour guard already applied to the regular candidate.

## Testing
Reproduced on master: get_prev from 03:00 returned 02:30+11:00 and match("0 * * * *", 02:30) was true; both now agree with get_next. Added regression tests for zoneinfo and pytz covering all three APIs. Suite passes apart from four pre-existing failures identical on clean master.

## Checklist
- [x] Bug reproduced before the fix
- [x] Root cause identified
- [x] Bug fixed
- [x] Tests passed
