### PR TITLE
Fix AssertionError in pytz ambiguous-time handling for negative-DST zones

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ Changelog
 
 Bugfixes
 ~~~~~~~~
+- Fix ``get_next``/``get_prev`` raising ``AssertionError`` for pytz timezones whose
+  tzdb encoding uses a negative DST offset (for example ``Europe/Dublin``). At an
+  ambiguous local time the resolution assumed the ``is_dst=True`` interpretation is
+  always the later UTC instant; such zones invert that ordering, so the internal
+  assertion tripped and evaluation crashed instead of returning a fire time. Both
+  interpretations are now ordered by their absolute instants and the first one
+  satisfying the successor requirement in the requested direction is returned.
+  [#267, @abhijeet117]
 - Fix ``get_next``/``get_prev`` raising ``CroniterBadDateError`` when day-of-month and day-of-week are both restricted and the day-of-month can never occur in the selected month (e.g. ``0 0 31 2 0``). Under the Vixie OR semantics the unsatisfiable side now contributes no dates instead of aborting the whole expression, and ``match()`` and ``croniter_range()``, which swallow the error, no longer return silently wrong results for these expressions. [b245ab6, #243, @semx, @MildlyMeticulous]
 - Fix hashed divisions (``H/{divisor}``, ``H({begin}-{end})/{divisor}``) when the divisor
   is as wide as, or wider than, the range it is drawn from. Three symptoms, one cause:

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -204,15 +204,20 @@ def _add_tzinfo(
                 break
             return result, False
         except pytz.AmbiguousTimeError:
-            closer = localize(date, is_dst=not is_prev)
-            farther = localize(date, is_dst=is_prev)
-            # TODO: Check negative DST
-            assert (closer.astimezone(UTC_DT) > farther.astimezone(UTC_DT)) == is_prev
-            if _is_successor(closer, previous_date, is_prev):
-                result = closer
-            else:
-                assert _is_successor(farther, previous_date, is_prev)
-                result = farther
+            candidates = [
+                localize(date, is_dst=True),
+                localize(date, is_dst=False),
+            ]
+            # Depending on the sign of the zone's DST offset, either
+            # interpretation can be the earlier instant, so order by the
+            # actual absolute times instead of assuming is_dst ordering.
+            candidates.sort(key=lambda value: value.astimezone(UTC_DT))
+            if is_prev:
+                candidates.reverse()
+            for candidate in candidates:
+                if _is_successor(candidate, previous_date, is_prev):
+                    return candidate, True
+            return candidates[-1], True
         return result, True
 
     result = date.replace(fold=1 if is_prev else 0, tzinfo=previous_date.tzinfo)

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -1835,6 +1835,31 @@ class CroniterTest(base.TestCase):
             ],
         )
 
+    def test_dst_negative_dst_zone_ambiguous_pytz(self):
+        """Test Europe/Dublin (negative DST encoding) fall-back ambiguity.
+
+        On 2019-10-27 local 01:00 occurs twice (IST +01:00 first, then
+        GMT +00:00), so both instants are valid fire times for an hourly
+        schedule. croniter used to raise AssertionError from the pytz
+        ambiguous-time handling instead of enumerating them.
+        """
+        tz = pytz.timezone("Europe/Dublin")
+        start = tz.localize(datetime(2019, 10, 26, 12, 0))
+        it = croniter("0 1 * * *", start)
+        ret = [
+            it.get_next(datetime).isoformat(),
+            it.get_next(datetime).isoformat(),
+            it.get_next(datetime).isoformat(),
+        ]
+        self.assertEqual(
+            ret,
+            [
+                "2019-10-27T01:00:00+01:00",
+                "2019-10-27T01:00:00+00:00",
+                "2019-10-28T01:00:00+00:00",
+            ],
+        )
+
     def test_nth_wday_simple(self):
         def f(y, m, w):
             return croniter._get_nth_weekday_of_month(y, m, w)


### PR DESCRIPTION
## Summary
get_next and get_prev raised AssertionError for cron expressions evaluated with pytz in zones whose tzdb encoding uses a negative DST offset, such as Europe/Dublin. The ambiguous-time resolution assumed the is_dst=True interpretation is always the later UTC instant; Dublin's encoding (standard IST, daylight GMT) inverts that ordering. Both interpretations are now ordered by their absolute instants and the first one satisfying the successor requirement in the requested direction is returned.

## Testing
Reproduced on master: croniter("0 1 * * *", pytz Europe/Dublin localized 2019-10-26 12:00).get_next() raised AssertionError at the fall-back transition. Added a regression test asserting both ambiguous-hour instants fire in order followed by the next day; it fails before the fix and passes after. Full test suite matches the pre-existing baseline.

## Checklist
- [x] Bug reproduced before the fix
- [x] Root cause identified
- [x] Bug fixed
- [x] Tests passed
